### PR TITLE
Add support for confd generated config file

### DIFF
--- a/telegraf/1.0/alpine/entrypoint.sh
+++ b/telegraf/1.0/alpine/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+while [ ! -f "/etc/telegraf/telegraf.conf" ]; do
+    sleep 1
+done
+
 if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi


### PR DESCRIPTION
Confd files are usually generated by a sidekickcontainer, which volumes are shared with the main container. As either of:
- generating config files takes some time
- sidekick starts before main container
  can happen, this just loops over the config file folder and only contines when once available.

A very common pattern for confd managed config files.
