### PR TITLE
[telegraf:alpine] Keep `ca-certificates` installed in image

### DIFF
--- a/telegraf/1.0/alpine/Dockerfile
+++ b/telegraf/1.0/alpine/Dockerfile
@@ -1,8 +1,11 @@
 FROM alpine:3.4
 
 ENV TELEGRAF_VERSION 1.0.0
-RUN apk add --no-cache --virtual .build-deps wget gnupg tar ca-certificates && \
-    update-ca-certificates && \
+
+RUN apk add --no-cache ca-certificates && \
+    update-ca-certificates
+
+RUN apk add --no-cache --virtual .build-deps wget gnupg tar && \
     gpg --keyserver hkp://ha.pool.sks-keyservers.net \
         --recv-keys 05CE15085FC09D18E99EFB22684A14CF2582E0C5 && \
     wget -q https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}-static_linux_amd64.tar.gz.asc && \


### PR DESCRIPTION
If `ca-certificates` is missing, `telegraf` can't deal with `https`, ex:

    ERROR in input [haproxy]: Errors encountered: [Unable to connect to haproxy server 'https://foo.com/haproxy?stats/;csv': Get https://foo.com/haproxy?stats/;csv: x509: failed to load system roots and no roots provided]