### PR TITLE
Remove port 8083 from the exposed ports in influxdb alpine

### DIFF
--- a/influxdb/1.1/alpine/Dockerfile
+++ b/influxdb/1.1/alpine/Dockerfile
@@ -17,7 +17,7 @@ RUN apk add --no-cache --virtual .build-deps wget gnupg tar ca-certificates && \
     apk del .build-deps
 COPY influxdb.conf /etc/influxdb/influxdb.conf
 
-EXPOSE 8083 8086
+EXPOSE 8086
 
 VOLUME /var/lib/influxdb
 


### PR DESCRIPTION
It was never supposed to be exposed, but it got copied from the main
image before that port was removed from the main image during initial
development.

Now that the admin interface is deprecated and isn't on by default,
there's even less of a reason for it to be exposed.