### PR TITLE
Set the boltdb path for chronograf

### DIFF
--- a/chronograf/1.3/alpine/entrypoint.sh
+++ b/chronograf/1.3/alpine/entrypoint.sh
@@ -5,4 +5,8 @@ if [ "${1:0:1}" = '-' ]; then
     set -- chronograf "$@"
 fi
 
+if [ "$1" = 'chronograf' ]; then
+  export BOLT_PATH=${BOLT_PATH:-/var/lib/chronograf/chronograf-v1.db}
+fi
+
 exec "$@"

--- a/chronograf/1.3/entrypoint.sh
+++ b/chronograf/1.3/entrypoint.sh
@@ -5,4 +5,8 @@ if [ "${1:0:1}" = '-' ]; then
     set -- chronograf "$@"
 fi
 
+if [ "$1" = 'chronograf' ]; then
+  export BOLT_PATH=${BOLT_PATH:-/var/lib/chronograf/chronograf-v1.db}
+fi
+
 exec "$@"


### PR DESCRIPTION
The path is now set to /var/lib/chronograf/chronograf-v1.db by default.
This should be inside of the default volume automatically. It is also
possible to override the path using an environment variable or the
command line option.

Fixes #97.