### PR TITLE
Add net-snmp-tools (snmp) package to Telegraf containers.

### DIFF
--- a/telegraf/1.2/Dockerfile
+++ b/telegraf/1.2/Dockerfile
@@ -1,5 +1,9 @@
 FROM buildpack-deps:trusty-curl
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends snmp && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \

--- a/telegraf/1.2/alpine/Dockerfile
+++ b/telegraf/1.2/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.5
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache iputils ca-certificates && \
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools && \
     update-ca-certificates
 
 ENV TELEGRAF_VERSION 1.2.1

--- a/telegraf/1.3/Dockerfile
+++ b/telegraf/1.3/Dockerfile
@@ -1,5 +1,9 @@
 FROM buildpack-deps:trusty-curl
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends snmp && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \

--- a/telegraf/1.3/alpine/Dockerfile
+++ b/telegraf/1.3/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.5
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache iputils ca-certificates && \
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools && \
     update-ca-certificates
 
 ENV TELEGRAF_VERSION 1.3.3


### PR DESCRIPTION
Include net-snmp-tools package to Alpine container as it is needed by SNMP Telegraf plugin.
MIB lookups and proper SNMP table support require utilities "snmptranslate" and "snmptable" which are available in this package.