### PR TITLE
chmod +x entypoints.sh in dockerfiles

### DIFF
--- a/telegraf/1.3/Dockerfile
+++ b/telegraf/1.3/Dockerfile
@@ -31,5 +31,6 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
 EXPOSE 8125/udp 8092/udp 8094
 
 COPY entrypoint.sh /entrypoint.sh
+RUN ["chmod", "+x", "/entrypoint.sh"]
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["telegraf"]

--- a/telegraf/1.3/alpine/Dockerfile
+++ b/telegraf/1.3/alpine/Dockerfile
@@ -29,5 +29,6 @@ RUN set -ex && \
 EXPOSE 8125/udp 8092/udp 8094
 
 COPY entrypoint.sh /entrypoint.sh
+RUN ["chmod", "+x", "/entrypoint.sh"]
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["telegraf"]

--- a/telegraf/1.4/Dockerfile
+++ b/telegraf/1.4/Dockerfile
@@ -31,5 +31,6 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
 EXPOSE 8125/udp 8092/udp 8094
 
 COPY entrypoint.sh /entrypoint.sh
+RUN ["chmod", "+x", "/entrypoint.sh"]
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["telegraf"]

--- a/telegraf/1.4/alpine/Dockerfile
+++ b/telegraf/1.4/alpine/Dockerfile
@@ -29,5 +29,6 @@ RUN set -ex && \
 EXPOSE 8125/udp 8092/udp 8094
 
 COPY entrypoint.sh /entrypoint.sh
+RUN ["chmod", "+x", "/entrypoint.sh"]
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["telegraf"]


### PR DESCRIPTION
_entrypoint.sh_ must be marked as executable to start the container. Therefore, you can do it yourself or add command to the image.