### PR TITLE
install procps in telegraf image to fix "Could not find pgrep binary"…

### DIFF
--- a/telegraf/1.3/Dockerfile
+++ b/telegraf/1.3/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:stretch-curl
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends snmp && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends snmp procps && \
     rm -rf /var/lib/apt/lists/*
 
 RUN set -ex && \

--- a/telegraf/1.3/alpine/Dockerfile
+++ b/telegraf/1.3/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.5
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache iputils ca-certificates net-snmp-tools && \
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps && \
     update-ca-certificates
 
 ENV TELEGRAF_VERSION 1.3.5

--- a/telegraf/1.4/Dockerfile
+++ b/telegraf/1.4/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:stretch-curl
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends snmp && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends snmp procps && \
     rm -rf /var/lib/apt/lists/*
 
 RUN set -ex && \

--- a/telegraf/1.4/alpine/Dockerfile
+++ b/telegraf/1.4/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.5
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache iputils ca-certificates net-snmp-tools && \
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps && \
     update-ca-certificates
 
 ENV TELEGRAF_VERSION 1.4.1


### PR DESCRIPTION
we are using docker image  telegraf:1.4.0
https://hub.docker.com/r/library/telegraf/tags/

and we got this error:

```
2017-10-04T04:59:10Z E! Error in plugin [inputs.procstat]: E! Error: procstat getting process, exe: [telegraf] pidfile: [] pattern: [] user: [] Could not find pgrep binary: exec: "pgrep": executable file not found in $PATH
2017-10-04T04:59:20Z E! Error in plugin [inputs.procstat]: E! Error: procstat getting process, exe: [telegraf] pidfile: [] pattern: [] user: [] Could not find pgrep binary: exec: "pgrep": executable file not found in $PATH
```

Note: I tried to test with ``telegraf:1.4.1`` image, and also get above error 
The reason is ``procps`` was not installed
I checked in ``telegraf`` container:

```
root@telegraf:/# pgrep telegraf
bash: pgrep: command not found
```

I installed ``procps`` and the error was fixed
