### PR TITLE
Disable SSL during InfluxDB initialization

### DIFF
--- a/influxdb/1.2/alpine/init-influxdb.sh
+++ b/influxdb/1.2/alpine/init-influxdb.sh
@@ -32,7 +32,7 @@ if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-ent
 
 	INFLUXDB_INIT_PORT="8086"
 
-	INFLUXDB_HTTP_BIND_ADDRESS=127.0.0.1:$INFLUXDB_INIT_PORT influxd "$@" &
+	INFLUXDB_HTTP_BIND_ADDRESS=127.0.0.1:$INFLUXDB_INIT_PORT INFLUXDB_HTTP_HTTPS_ENABLED=false influxd "$@" &
 	pid="$!"
 
 	INFLUX_CMD="influx -host 127.0.0.1 -port $INFLUXDB_INIT_PORT -execute "

--- a/influxdb/1.2/init-influxdb.sh
+++ b/influxdb/1.2/init-influxdb.sh
@@ -32,7 +32,7 @@ if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-ent
 
 	INFLUXDB_INIT_PORT="8086"
 
-	INFLUXDB_HTTP_BIND_ADDRESS=127.0.0.1:$INFLUXDB_INIT_PORT influxd "$@" &
+	INFLUXDB_HTTP_BIND_ADDRESS=127.0.0.1:$INFLUXDB_INIT_PORT INFLUXDB_HTTP_HTTPS_ENABLED=false influxd "$@" &
 	pid="$!"
 
 	INFLUX_CMD="influx -host 127.0.0.1 -port $INFLUXDB_INIT_PORT -execute "

--- a/influxdb/1.3/alpine/init-influxdb.sh
+++ b/influxdb/1.3/alpine/init-influxdb.sh
@@ -32,7 +32,7 @@ if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-ent
 
 	INFLUXDB_INIT_PORT="8086"
 
-	INFLUXDB_HTTP_BIND_ADDRESS=127.0.0.1:$INFLUXDB_INIT_PORT influxd "$@" &
+	INFLUXDB_HTTP_BIND_ADDRESS=127.0.0.1:$INFLUXDB_INIT_PORT INFLUXDB_HTTP_HTTPS_ENABLED=false influxd "$@" &
 	pid="$!"
 
 	INFLUX_CMD="influx -host 127.0.0.1 -port $INFLUXDB_INIT_PORT -execute "

--- a/influxdb/1.3/init-influxdb.sh
+++ b/influxdb/1.3/init-influxdb.sh
@@ -32,7 +32,7 @@ if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-ent
 
 	INFLUXDB_INIT_PORT="8086"
 
-	INFLUXDB_HTTP_BIND_ADDRESS=127.0.0.1:$INFLUXDB_INIT_PORT influxd "$@" &
+	INFLUXDB_HTTP_BIND_ADDRESS=127.0.0.1:$INFLUXDB_INIT_PORT INFLUXDB_HTTP_HTTPS_ENABLED=false influxd "$@" &
 	pid="$!"
 
 	INFLUX_CMD="influx -host 127.0.0.1 -port $INFLUXDB_INIT_PORT -execute "

--- a/influxdb/nightly/alpine/init-influxdb.sh
+++ b/influxdb/nightly/alpine/init-influxdb.sh
@@ -32,7 +32,7 @@ if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-ent
 
 	INFLUXDB_INIT_PORT="8086"
 
-	INFLUXDB_HTTP_BIND_ADDRESS=127.0.0.1:$INFLUXDB_INIT_PORT influxd "$@" &
+	INFLUXDB_HTTP_BIND_ADDRESS=127.0.0.1:$INFLUXDB_INIT_PORT INFLUXDB_HTTP_HTTPS_ENABLED=false influxd "$@" &
 	pid="$!"
 
 	INFLUX_CMD="influx -host 127.0.0.1 -port $INFLUXDB_INIT_PORT -execute "

--- a/influxdb/nightly/init-influxdb.sh
+++ b/influxdb/nightly/init-influxdb.sh
@@ -32,7 +32,7 @@ if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-ent
 
 	INFLUXDB_INIT_PORT="8086"
 
-	INFLUXDB_HTTP_BIND_ADDRESS=127.0.0.1:$INFLUXDB_INIT_PORT influxd "$@" &
+	INFLUXDB_HTTP_BIND_ADDRESS=127.0.0.1:$INFLUXDB_INIT_PORT INFLUXDB_HTTP_HTTPS_ENABLED=false influxd "$@" &
 	pid="$!"
 
 	INFLUX_CMD="influx -host 127.0.0.1 -port $INFLUXDB_INIT_PORT -execute "


### PR DESCRIPTION
The current init script fails to initialize the database when the container is started with `INFLUXDB_HTTP_HTTPS_ENABLED=true` as no `-ssl` flag is passed to the `influx` tool in this case.

This PR changes the init script to set `INFLUXDB_HTTP_HTTPS_ENABLED=false` when starting the temporary `influxd` which is only used during initialization. This avoid having to figure out whether `-unsafeSsl` is need in addition to `-ssl` for self-signed certificates.