### PR TITLE
Update for influxdb 1.3.7

### DIFF
--- a/influxdb/1.3/Dockerfile
+++ b/influxdb/1.3/Dockerfile
@@ -9,7 +9,7 @@ RUN set -ex && \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
     done
 
-ENV INFLUXDB_VERSION 1.3.6
+ENV INFLUXDB_VERSION 1.3.7
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     case "${dpkgArch##*-}" in \
       amd64) ARCH='amd64';; \

--- a/influxdb/1.3/alpine/Dockerfile
+++ b/influxdb/1.3/alpine/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.5
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash
 
-ENV INFLUXDB_VERSION 1.3.6
+ENV INFLUXDB_VERSION 1.3.7
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps wget gnupg tar ca-certificates && \
     update-ca-certificates && \
@@ -18,9 +18,11 @@ RUN set -ex && \
     wget -q https://dl.influxdata.com/influxdb/releases/influxdb-${INFLUXDB_VERSION}-static_linux_amd64.tar.gz && \
     gpg --batch --verify influxdb-${INFLUXDB_VERSION}-static_linux_amd64.tar.gz.asc influxdb-${INFLUXDB_VERSION}-static_linux_amd64.tar.gz && \
     mkdir -p /usr/src && \
-    tar -xzf influxdb-${INFLUXDB_VERSION}-static_linux_amd64.tar.gz && \
-    chmod +x /usr/bin/influx_inspect /usr/bin/influx_stress /usr/bin/influxd /usr/bin/influx_tsm /usr/bin/influx && \
-    rm -rf *.tar.gz* /usr/src /root/.gnupg /etc/influxdb/influxdb.conf && \
+    tar -C /usr/src -xzf influxdb-${INFLUXDB_VERSION}-static_linux_amd64.tar.gz && \
+    rm -f /usr/src/influxdb-*/influxdb.conf && \
+    chmod +x /usr/src/influxdb-*/* && \
+    cp -a /usr/src/influxdb-*/* /usr/bin/ && \
+    rm -rf *.tar.gz* /usr/src /root/.gnupg && \
     apk del .build-deps
 COPY influxdb.conf /etc/influxdb/influxdb.conf
 


### PR DESCRIPTION
Reverts back to the <= 1.3.5 way of extracting the static tarball, now
that 1.3.7 restores that packaging layout.