### PR TITLE
Upgrade base Alpine Linux images to 3.6

### DIFF
--- a/chronograf/1.3/alpine/Dockerfile
+++ b/chronograf/1.3/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/influxdb/1.3/alpine/Dockerfile
+++ b/influxdb/1.3/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash

--- a/influxdb/1.4/alpine/Dockerfile
+++ b/influxdb/1.4/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash

--- a/influxdb/nightly/alpine/Dockerfile
+++ b/influxdb/nightly/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 RUN apk add --no-cache bash
 

--- a/kapacitor/1.2/alpine/Dockerfile
+++ b/kapacitor/1.2/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/kapacitor/1.3/alpine/Dockerfile
+++ b/kapacitor/1.3/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/telegraf/1.3/alpine/Dockerfile
+++ b/telegraf/1.3/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache iputils ca-certificates net-snmp-tools && \

--- a/telegraf/1.4/alpine/Dockerfile
+++ b/telegraf/1.4/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache iputils ca-certificates net-snmp-tools && \


### PR DESCRIPTION
Updates all Alpine Linux images to the latest version (3.6). Tested running the `./circle-test.sh` script from the project root.