### PR TITLE
Relax bootstrapping check

### DIFF
--- a/influxdb/1.3/alpine/init-influxdb.sh
+++ b/influxdb/1.3/alpine/init-influxdb.sh
@@ -11,7 +11,7 @@ fi
 
 INIT_USERS=$([ ! -z "$AUTH_ENABLED" ] && [ ! -z "$INFLUXDB_ADMIN_USER" ] && echo 1 || echo)
 
-if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -A /var/lib/influxdb)" ]; then
+if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -d /var/lib/influxdb/meta 2>/dev/null)" ]; then
 
 	INIT_QUERY=""
 	CREATE_DB_QUERY="CREATE DATABASE $INFLUXDB_DB"

--- a/influxdb/1.3/init-influxdb.sh
+++ b/influxdb/1.3/init-influxdb.sh
@@ -11,7 +11,7 @@ fi
 
 INIT_USERS=$([ ! -z "$AUTH_ENABLED" ] && [ ! -z "$INFLUXDB_ADMIN_USER" ] && echo 1 || echo)
 
-if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -A /var/lib/influxdb)" ]; then
+if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -d /var/lib/influxdb/meta 2>/dev/null)" ]; then
 
 	INIT_QUERY=""
 	CREATE_DB_QUERY="CREATE DATABASE $INFLUXDB_DB"

--- a/influxdb/1.4/alpine/init-influxdb.sh
+++ b/influxdb/1.4/alpine/init-influxdb.sh
@@ -11,7 +11,7 @@ fi
 
 INIT_USERS=$([ ! -z "$AUTH_ENABLED" ] && [ ! -z "$INFLUXDB_ADMIN_USER" ] && echo 1 || echo)
 
-if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -A /var/lib/influxdb)" ]; then
+if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -d /var/lib/influxdb/meta 2>/dev/null)" ]; then
 
 	INIT_QUERY=""
 	CREATE_DB_QUERY="CREATE DATABASE $INFLUXDB_DB"

--- a/influxdb/1.4/init-influxdb.sh
+++ b/influxdb/1.4/init-influxdb.sh
@@ -11,7 +11,7 @@ fi
 
 INIT_USERS=$([ ! -z "$AUTH_ENABLED" ] && [ ! -z "$INFLUXDB_ADMIN_USER" ] && echo 1 || echo)
 
-if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -A /var/lib/influxdb)" ]; then
+if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -d /var/lib/influxdb/meta 2>/dev/null)" ]; then
 
 	INIT_QUERY=""
 	CREATE_DB_QUERY="CREATE DATABASE $INFLUXDB_DB"

--- a/influxdb/nightly/alpine/init-influxdb.sh
+++ b/influxdb/nightly/alpine/init-influxdb.sh
@@ -11,7 +11,7 @@ fi
 
 INIT_USERS=$([ ! -z "$AUTH_ENABLED" ] && [ ! -z "$INFLUXDB_ADMIN_USER" ] && echo 1 || echo)
 
-if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -A /var/lib/influxdb)" ]; then
+if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -d /var/lib/influxdb/meta 2>/dev/null)" ]; then
 
 	INIT_QUERY=""
 	CREATE_DB_QUERY="CREATE DATABASE $INFLUXDB_DB"

--- a/influxdb/nightly/init-influxdb.sh
+++ b/influxdb/nightly/init-influxdb.sh
@@ -11,7 +11,7 @@ fi
 
 INIT_USERS=$([ ! -z "$AUTH_ENABLED" ] && [ ! -z "$INFLUXDB_ADMIN_USER" ] && echo 1 || echo)
 
-if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -A /var/lib/influxdb)" ]; then
+if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -d /var/lib/influxdb/meta 2>/dev/null)" ]; then
 
 	INIT_QUERY=""
 	CREATE_DB_QUERY="CREATE DATABASE $INFLUXDB_DB"


### PR DESCRIPTION
Relax bootstrapping check in `init-influxdb.sh` to allow for /var/lib/
influxdb being a mount point.

If this script is generated, please point me to its source repo and I
can make a PR there instead.

Closes #163