### PR TITLE
Use iputils-ping in Telegraf debian docker image

### DIFF
--- a/telegraf/1.5/Dockerfile
+++ b/telegraf/1.5/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:stretch-curl
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends snmp procps && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps && \
     rm -rf /var/lib/apt/lists/*
 
 RUN set -ex && \


### PR DESCRIPTION
Workaround for compatibility issue with `inetutils-ping`, alpine image is not affected.

See https://github.com/influxdata/telegraf/issues/3295