### PR TITLE
Update init-influxdb.sh

### DIFF
--- a/influxdb/1.5/alpine/init-influxdb.sh
+++ b/influxdb/1.5/alpine/init-influxdb.sh
@@ -14,7 +14,7 @@ INIT_USERS=$([ ! -z "$AUTH_ENABLED" ] && [ ! -z "$INFLUXDB_ADMIN_USER" ] && echo
 if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -d /var/lib/influxdb/meta 2>/dev/null)" ]; then
 
 	INIT_QUERY=""
-	CREATE_DB_QUERY="CREATE DATABASE $INFLUXDB_DB"
+	CREATE_DB_QUERY="CREATE DATABASE \"$INFLUXDB_DB\""
 
 	if [ ! -z "$INIT_USERS" ]; then
 


### PR DESCRIPTION
Loop when try to create the database with parameters :

Example :
{code}
+ for i in '{30..0}'
+ influx -host 127.0.0.1 -port 8086 -execute 'CREATE DATABASE database'
+ echo 'influxdb init process in progress...'
influxdb init process in progress...
+ sleep 1
+ for i in '{30..0}'
+ influx -host 127.0.0.1 -port 8086 -execute 'CREATE DATABASE database'
influxdb init process in progress...
+ echo 'influxdb init process in progress...'
+ sleep 1
{code}