### PR TITLE
Add explicit gpg keyserver URL

### DIFF
--- a/chronograf/1.4/Dockerfile
+++ b/chronograf/1.4/Dockerfile
@@ -6,6 +6,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/chronograf/1.4/alpine/Dockerfile
+++ b/chronograf/1.4/alpine/Dockerfile
@@ -11,6 +11,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/chronograf/1.5/Dockerfile
+++ b/chronograf/1.5/Dockerfile
@@ -6,6 +6,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/chronograf/1.5/alpine/Dockerfile
+++ b/chronograf/1.5/alpine/Dockerfile
@@ -11,6 +11,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/influxdb/1.4/Dockerfile
+++ b/influxdb/1.4/Dockerfile
@@ -4,6 +4,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/influxdb/1.4/alpine/Dockerfile
+++ b/influxdb/1.4/alpine/Dockerfile
@@ -10,6 +10,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/influxdb/1.5/Dockerfile
+++ b/influxdb/1.5/Dockerfile
@@ -4,6 +4,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/influxdb/1.5/alpine/Dockerfile
+++ b/influxdb/1.5/alpine/Dockerfile
@@ -10,6 +10,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/influxdb/1.5/data/Dockerfile
+++ b/influxdb/1.5/data/Dockerfile
@@ -4,6 +4,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/influxdb/1.5/data/alpine/Dockerfile
+++ b/influxdb/1.5/data/alpine/Dockerfile
@@ -10,6 +10,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/influxdb/1.5/meta/Dockerfile
+++ b/influxdb/1.5/meta/Dockerfile
@@ -4,6 +4,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/influxdb/1.5/meta/alpine/Dockerfile
+++ b/influxdb/1.5/meta/alpine/Dockerfile
@@ -10,6 +10,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/influxdb/nightly/Dockerfile
+++ b/influxdb/nightly/Dockerfile
@@ -4,6 +4,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/influxdb/nightly/alpine/Dockerfile
+++ b/influxdb/nightly/alpine/Dockerfile
@@ -8,6 +8,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/kapacitor/1.4/Dockerfile
+++ b/kapacitor/1.4/Dockerfile
@@ -9,6 +9,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/kapacitor/1.4/alpine/Dockerfile
+++ b/kapacitor/1.4/alpine/Dockerfile
@@ -11,6 +11,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/kapacitor/1.5/Dockerfile
+++ b/kapacitor/1.5/Dockerfile
@@ -9,6 +9,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/kapacitor/1.5/alpine/Dockerfile
+++ b/kapacitor/1.5/alpine/Dockerfile
@@ -11,6 +11,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/telegraf/1.4/Dockerfile
+++ b/telegraf/1.4/Dockerfile
@@ -8,6 +8,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/telegraf/1.4/alpine/Dockerfile
+++ b/telegraf/1.4/alpine/Dockerfile
@@ -11,6 +11,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/telegraf/1.5/Dockerfile
+++ b/telegraf/1.5/Dockerfile
@@ -8,6 +8,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/telegraf/1.5/alpine/Dockerfile
+++ b/telegraf/1.5/alpine/Dockerfile
@@ -11,6 +11,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/telegraf/1.6/Dockerfile
+++ b/telegraf/1.6/Dockerfile
@@ -8,6 +8,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \

--- a/telegraf/1.6/alpine/Dockerfile
+++ b/telegraf/1.6/alpine/Dockerfile
@@ -11,6 +11,7 @@ RUN set -ex && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \
+        gpg --keyserver hkp://ha.pool.sks-keyservers.net:11371 --recv-keys "$key" || \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \


### PR DESCRIPTION
The existing commands always threw the error:

    gpg: keyserver receive failed: Server indicated a failure
