### PR TITLE
init-influxdb.sh: Fix #224 and support keywords as database name

### DIFF
--- a/influxdb/1.5/alpine/init-influxdb.sh
+++ b/influxdb/1.5/alpine/init-influxdb.sh
@@ -14,7 +14,7 @@ INIT_USERS=$([ ! -z "$AUTH_ENABLED" ] && [ ! -z "$INFLUXDB_ADMIN_USER" ] && echo
 if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -d /var/lib/influxdb/meta 2>/dev/null)" ]; then
 
 	INIT_QUERY=""
-	CREATE_DB_QUERY="CREATE DATABASE $INFLUXDB_DB"
+	CREATE_DB_QUERY="CREATE DATABASE \"$INFLUXDB_DB\""
 
 	if [ ! -z "$INIT_USERS" ]; then
 

--- a/influxdb/1.5/data/alpine/init-influxdb.sh
+++ b/influxdb/1.5/data/alpine/init-influxdb.sh
@@ -14,7 +14,7 @@ INIT_USERS=$([ ! -z "$AUTH_ENABLED" ] && [ ! -z "$INFLUXDB_ADMIN_USER" ] && echo
 if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -d /var/lib/influxdb/meta 2>/dev/null)" ]; then
 
 	INIT_QUERY=""
-	CREATE_DB_QUERY="CREATE DATABASE $INFLUXDB_DB"
+	CREATE_DB_QUERY="CREATE DATABASE \"$INFLUXDB_DB\""
 
 	if [ ! -z "$INIT_USERS" ]; then
 

--- a/influxdb/1.5/data/init-influxdb.sh
+++ b/influxdb/1.5/data/init-influxdb.sh
@@ -14,7 +14,7 @@ INIT_USERS=$([ ! -z "$AUTH_ENABLED" ] && [ ! -z "$INFLUXDB_ADMIN_USER" ] && echo
 if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -d /var/lib/influxdb/meta 2>/dev/null)" ]; then
 
 	INIT_QUERY=""
-	CREATE_DB_QUERY="CREATE DATABASE $INFLUXDB_DB"
+	CREATE_DB_QUERY="CREATE DATABASE \"$INFLUXDB_DB\""
 
 	if [ ! -z "$INIT_USERS" ]; then
 

--- a/influxdb/1.5/init-influxdb.sh
+++ b/influxdb/1.5/init-influxdb.sh
@@ -14,7 +14,7 @@ INIT_USERS=$([ ! -z "$AUTH_ENABLED" ] && [ ! -z "$INFLUXDB_ADMIN_USER" ] && echo
 if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -d /var/lib/influxdb/meta 2>/dev/null)" ]; then
 
 	INIT_QUERY=""
-	CREATE_DB_QUERY="CREATE DATABASE $INFLUXDB_DB"
+	CREATE_DB_QUERY="CREATE DATABASE \"$INFLUXDB_DB\""
 
 	if [ ! -z "$INIT_USERS" ]; then
 

--- a/influxdb/1.6/alpine/init-influxdb.sh
+++ b/influxdb/1.6/alpine/init-influxdb.sh
@@ -14,7 +14,7 @@ INIT_USERS=$([ ! -z "$AUTH_ENABLED" ] && [ ! -z "$INFLUXDB_ADMIN_USER" ] && echo
 if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -d /var/lib/influxdb/meta 2>/dev/null)" ]; then
 
 	INIT_QUERY=""
-	CREATE_DB_QUERY="CREATE DATABASE $INFLUXDB_DB"
+	CREATE_DB_QUERY="CREATE DATABASE \"$INFLUXDB_DB\""
 
 	if [ ! -z "$INIT_USERS" ]; then
 

--- a/influxdb/1.6/data/alpine/init-influxdb.sh
+++ b/influxdb/1.6/data/alpine/init-influxdb.sh
@@ -14,7 +14,7 @@ INIT_USERS=$([ ! -z "$AUTH_ENABLED" ] && [ ! -z "$INFLUXDB_ADMIN_USER" ] && echo
 if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -d /var/lib/influxdb/meta 2>/dev/null)" ]; then
 
 	INIT_QUERY=""
-	CREATE_DB_QUERY="CREATE DATABASE $INFLUXDB_DB"
+	CREATE_DB_QUERY="CREATE DATABASE \"$INFLUXDB_DB\""
 
 	if [ ! -z "$INIT_USERS" ]; then
 

--- a/influxdb/1.6/data/init-influxdb.sh
+++ b/influxdb/1.6/data/init-influxdb.sh
@@ -14,7 +14,7 @@ INIT_USERS=$([ ! -z "$AUTH_ENABLED" ] && [ ! -z "$INFLUXDB_ADMIN_USER" ] && echo
 if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -d /var/lib/influxdb/meta 2>/dev/null)" ]; then
 
 	INIT_QUERY=""
-	CREATE_DB_QUERY="CREATE DATABASE $INFLUXDB_DB"
+	CREATE_DB_QUERY="CREATE DATABASE \"$INFLUXDB_DB\""
 
 	if [ ! -z "$INIT_USERS" ]; then
 

--- a/influxdb/1.6/init-influxdb.sh
+++ b/influxdb/1.6/init-influxdb.sh
@@ -14,7 +14,7 @@ INIT_USERS=$([ ! -z "$AUTH_ENABLED" ] && [ ! -z "$INFLUXDB_ADMIN_USER" ] && echo
 if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -d /var/lib/influxdb/meta 2>/dev/null)" ]; then
 
 	INIT_QUERY=""
-	CREATE_DB_QUERY="CREATE DATABASE $INFLUXDB_DB"
+	CREATE_DB_QUERY="CREATE DATABASE \"$INFLUXDB_DB\""
 
 	if [ ! -z "$INIT_USERS" ]; then
 

--- a/influxdb/circle-test.sh
+++ b/influxdb/circle-test.sh
@@ -83,11 +83,11 @@ test_default_with_auth_enabled_by_1() {
   cleanup
 }
 
-test_create_db() {
-  log_msg 'Executing test_create_db'
-  setup '--env INFLUXDB_DB=test_db'
+test_create_db_with_keyword_name() {
+  log_msg 'Executing test_create_db_with_keyword_name'
+  setup '--env INFLUXDB_DB=database'
 
-  assert_contains "$(influx 'SHOW DATABASES')" 'test_db' 'test_create_db: influxdb should contain a test_db database'
+  assert_contains "$(influx 'SHOW DATABASES')" 'database' 'test_create_db_with_keyword_name: influxdb should contain a database with name "database"'
 
   cleanup
 }
@@ -209,7 +209,7 @@ for path in $influxdb_dockerfiles; do
 
   test_default_with_auth_enabled_by_1
 
-  test_create_db
+  test_create_db_with_keyword_name
 
   test_create_admin
 

--- a/influxdb/nightly/alpine/init-influxdb.sh
+++ b/influxdb/nightly/alpine/init-influxdb.sh
@@ -14,7 +14,7 @@ INIT_USERS=$([ ! -z "$AUTH_ENABLED" ] && [ ! -z "$INFLUXDB_ADMIN_USER" ] && echo
 if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -d /var/lib/influxdb/meta 2>/dev/null)" ]; then
 
 	INIT_QUERY=""
-	CREATE_DB_QUERY="CREATE DATABASE $INFLUXDB_DB"
+	CREATE_DB_QUERY="CREATE DATABASE \"$INFLUXDB_DB\""
 
 	if [ ! -z "$INIT_USERS" ]; then
 

--- a/influxdb/nightly/init-influxdb.sh
+++ b/influxdb/nightly/init-influxdb.sh
@@ -14,7 +14,7 @@ INIT_USERS=$([ ! -z "$AUTH_ENABLED" ] && [ ! -z "$INFLUXDB_ADMIN_USER" ] && echo
 if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -d /var/lib/influxdb/meta 2>/dev/null)" ]; then
 
 	INIT_QUERY=""
-	CREATE_DB_QUERY="CREATE DATABASE $INFLUXDB_DB"
+	CREATE_DB_QUERY="CREATE DATABASE \"$INFLUXDB_DB\""
 
 	if [ ! -z "$INIT_USERS" ]; then
 


### PR DESCRIPTION
Hi,
this PR fixes init-influxdb.sh to support "1" as value for the INFLUXDB_HTTP_AUTH_ENABLED environment variable (https://github.com/influxdata/influxdata-docker/issues/224) and also adds support to give your database keyword names (e.g. "database", which was an issue in https://github.com/influxdata/influxdata-docker/issues/232#issuecomment-402857520).