### PR TITLE
Fix certificates on Alpine images

### DIFF
--- a/influxdb/1.6/alpine/Dockerfile
+++ b/influxdb/1.6/alpine/Dockerfile
@@ -5,8 +5,9 @@ RUN apk add --no-cache tzdata bash
 
 ENV INFLUXDB_VERSION 1.6.2
 RUN set -ex && \
-    apk add --no-cache --virtual .build-deps wget gnupg tar ca-certificates && \
+    apk add --no-cache ca-certificates && \
     update-ca-certificates && \
+    apk add --no-cache --virtual .build-deps wget gnupg tar && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \

--- a/influxdb/nightly/alpine/Dockerfile
+++ b/influxdb/nightly/alpine/Dockerfile
@@ -3,8 +3,9 @@ FROM alpine:3.6
 RUN apk add --no-cache bash
 
 RUN set -ex && \
-    apk add --no-cache --virtual .build-deps wget gnupg tar ca-certificates && \
+    apk add --no-cache ca-certificates && \
     update-ca-certificates && \
+    apk add --no-cache --virtual .build-deps wget gnupg tar && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
     do \


### PR DESCRIPTION
ca-certificates should remain installed even after updating certificates as removing will undo what was updated.

I discovered while connecting to one of my nodes using the influx command provided in the container. The Alpine image fails, but the regular image does not.
```
docker run -it influxdb:alpine influx -host HOST -ssl -username USER                                                                                                                                                           ~
Failed to connect to https://HOST:8086: Get https://HOST:8086/ping: x509: failed to load system roots and no roots provided
Please check your connection settings and ensure 'influxd' is running.
```