### PR TITLE
Updating to Alpine 3.8 to get past some current CVEs

### DIFF
--- a/chronograf/1.5/alpine/Dockerfile
+++ b/chronograf/1.5/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.8
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/chronograf/1.6/alpine/Dockerfile
+++ b/chronograf/1.6/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.8
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/chronograf/1.7/alpine/Dockerfile
+++ b/chronograf/1.7/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.8
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/influxdb/1.5/alpine/Dockerfile
+++ b/influxdb/1.5/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.8
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/1.5/data/alpine/Dockerfile
+++ b/influxdb/1.5/data/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.8
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/1.5/meta/alpine/Dockerfile
+++ b/influxdb/1.5/meta/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.8
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/1.6/alpine/Dockerfile
+++ b/influxdb/1.6/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/1.6/data/alpine/Dockerfile
+++ b/influxdb/1.6/data/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/1.6/meta/alpine/Dockerfile
+++ b/influxdb/1.6/meta/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/1.7/alpine/Dockerfile
+++ b/influxdb/1.7/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/nightly/alpine/Dockerfile
+++ b/influxdb/nightly/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.8
 
 RUN apk add --no-cache bash
 

--- a/kapacitor/1.4/alpine/Dockerfile
+++ b/kapacitor/1.4/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.8
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/kapacitor/1.5/alpine/Dockerfile
+++ b/kapacitor/1.5/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.8
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/telegraf/1.5/alpine/Dockerfile
+++ b/telegraf/1.5/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.8
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors && \

--- a/telegraf/1.6/alpine/Dockerfile
+++ b/telegraf/1.6/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.8
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors && \

--- a/telegraf/1.7/alpine/Dockerfile
+++ b/telegraf/1.7/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.8
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors && \

--- a/telegraf/1.8/alpine/Dockerfile
+++ b/telegraf/1.8/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.8
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors && \


### PR DESCRIPTION
I'm unable to promote these to production because of existing CVEs. It would be great to use an Alpine build that contains fixes for these.

- CVE-2015-9261 busybox 1.26.2-r11 medium fixed in 1.27.2-r11
- CVE-2018-12434 libressl2.5-libcrypto (libressl) 2.5.5-r2 medium fixed in 2.6.5-r0
- CVE-2018-12434 libressl2.5-libssl (libressl) 2.5.5-r2 medium fixed in 2.6.5-r0
- CVE-2018-12434 libressl2.5-libtls (libressl) 2.5.5-r2 medium fixed in 2.6.5-r0
- CVE-2015-9261 ssl_client (busybox) 1.26.2-r11 medium fixed in 1.27.2-r11
