### PR TITLE
Run as non-root user

### DIFF
--- a/kapacitor/1.4/Dockerfile
+++ b/kapacitor/1.4/Dockerfile
@@ -33,6 +33,7 @@ COPY kapacitor.conf /etc/kapacitor/kapacitor.conf
 EXPOSE 9092
 
 VOLUME /var/lib/kapacitor
+USER kapacitor:kapacitor
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/kapacitor/1.5/Dockerfile
+++ b/kapacitor/1.5/Dockerfile
@@ -33,6 +33,7 @@ COPY kapacitor.conf /etc/kapacitor/kapacitor.conf
 EXPOSE 9092
 
 VOLUME /var/lib/kapacitor
+USER kapacitor:kapacitor
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Hi, I'm Ted Hahn and I'm working on the Kubernetes team at Nordstrom. We're trying to implement [Pod Security Policies (PSP)](https://kubernetes.io/blog/2016/08/security-best-practices-kubernetes-deployment/) org-wide, and your container image is used by some of our teams. 

I'm trying to remedy the following attributes: 
- [ ] Runs as Root

Even though containers run in namespaces, it is possible (through bugs or by leveraging exposed parts of the host namespace) to "escape" the container and affect the root system. To reduce the surface area of these escapes, containers should run as a non-root user.