### PR TITLE
Install tzdata in telegraf alpine images

### DIFF
--- a/telegraf/1.10/alpine/Dockerfile
+++ b/telegraf/1.10/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.8
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors && \
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata && \
     update-ca-certificates
 
 ENV TELEGRAF_VERSION 1.10.0

--- a/telegraf/1.8/alpine/Dockerfile
+++ b/telegraf/1.8/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.8
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors && \
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata && \
     update-ca-certificates
 
 ENV TELEGRAF_VERSION 1.8.3

--- a/telegraf/1.9/alpine/Dockerfile
+++ b/telegraf/1.9/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.8
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors && \
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata && \
     update-ca-certificates
 
 ENV TELEGRAF_VERSION 1.9.5


### PR DESCRIPTION
Without `tzdata` package, configuring `grok_timezone` report errors like below:

```
2019-03-22T17:27:24Z I! Starting Telegraf 1.10.0
2019-03-22T17:27:24Z I! Using config file: /etc/telegraf/telegraf.conf
2019-03-22T17:27:24Z W! improper timezone supplied (Asia/Shanghai), setting loc to UTC
...
2019-03-22T17:27:24Z E! [telegraf] Error running agent: location: Asia/Shanghai could not be loaded as a location
```