### PR TITLE
upgrade: Alpine 3.9 for vulnerability patches

### DIFF
--- a/chronograf/1.5/alpine/Dockerfile
+++ b/chronograf/1.5/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/chronograf/1.6/alpine/Dockerfile
+++ b/chronograf/1.6/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/chronograf/1.7/alpine/Dockerfile
+++ b/chronograf/1.7/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/influxdb/1.5/alpine/Dockerfile
+++ b/influxdb/1.5/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/1.5/data/alpine/Dockerfile
+++ b/influxdb/1.5/data/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/1.5/meta/alpine/Dockerfile
+++ b/influxdb/1.5/meta/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/1.6/alpine/Dockerfile
+++ b/influxdb/1.6/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/1.6/data/alpine/Dockerfile
+++ b/influxdb/1.6/data/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/1.6/meta/alpine/Dockerfile
+++ b/influxdb/1.6/meta/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/1.7/alpine/Dockerfile
+++ b/influxdb/1.7/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/1.7/data/alpine/Dockerfile
+++ b/influxdb/1.7/data/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/1.7/meta/alpine/Dockerfile
+++ b/influxdb/1.7/meta/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/nightly/alpine/Dockerfile
+++ b/influxdb/nightly/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN apk add --no-cache bash
 

--- a/kapacitor/1.4/alpine/Dockerfile
+++ b/kapacitor/1.4/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/kapacitor/1.5/alpine/Dockerfile
+++ b/kapacitor/1.5/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/telegraf/1.10/alpine/Dockerfile
+++ b/telegraf/1.10/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors && \

--- a/telegraf/1.8/alpine/Dockerfile
+++ b/telegraf/1.8/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors && \

--- a/telegraf/1.9/alpine/Dockerfile
+++ b/telegraf/1.9/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors && \


### PR DESCRIPTION
## Summary

Alpine 3.8 has a vulnerable version of Busybox.
We need to update to version >= 1.30.1 to receive
the relevant security patches.

Alpine 3.9 has the patched version of Busybox.

## Package Update Summary

busybox version 1.28.4-r0 updated to >= 1.30.1


## Package Details

busybox
update to version >= 1.30.1
vulnarabilities:
high CVE-2018-20679 https://nvd.nist.gov/vuln/detail/CVE-2018-20679
high CVE-2019-5747 https://nvd.nist.gov/vuln/detail/CVE-2019-5747