### PR TITLE
Install smartmontools in telegraf docker

### DIFF
--- a/telegraf/1.18/Dockerfile
+++ b/telegraf/1.18/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:buster-curl
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors smartmontools && \
     rm -rf /var/lib/apt/lists/*
 
 RUN set -ex && \

--- a/telegraf/1.18/alpine/Dockerfile
+++ b/telegraf/1.18/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.14
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata su-exec && \
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors smartmontools tzdata su-exec && \
     update-ca-certificates
 
 ENV TELEGRAF_VERSION 1.18.3

--- a/telegraf/1.19/Dockerfile
+++ b/telegraf/1.19/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:buster-curl
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors smartmontools && \
     rm -rf /var/lib/apt/lists/*
 
 RUN set -ex && \

--- a/telegraf/1.19/alpine/Dockerfile
+++ b/telegraf/1.19/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.14
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata su-exec && \
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors smartmontools tzdata su-exec && \
     update-ca-certificates
 
 ENV TELEGRAF_VERSION 1.19.3

--- a/telegraf/1.20/Dockerfile
+++ b/telegraf/1.20/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:buster-curl
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors smartmontools && \
     rm -rf /var/lib/apt/lists/*
 
 RUN set -ex && \

--- a/telegraf/1.20/alpine/Dockerfile
+++ b/telegraf/1.20/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.14
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata su-exec && \
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors smartmontools tzdata su-exec && \
     update-ca-certificates
 
 ENV TELEGRAF_VERSION 1.20.4


### PR DESCRIPTION
This enables the `smart` plugin to be used.