### PR TITLE
feat(telegraf): telegraf config into environment variable

### DIFF
--- a/telegraf/1.12/alpine/entrypoint.sh
+++ b/telegraf/1.12/alpine/entrypoint.sh
@@ -1,6 +1,14 @@
 #!/bin/sh
 set -e
 
+# You can also set the TELEGRAF_CONFIG_CONTENT environment variable to pass some
+# Telegraf configuration without having to bind any volumes.
+# This is very usefull within kuberentes: the problem of using configmaps is that 
+# a change to a config doesn't restart telegraf
+if [ -n "$TELEGRAF_CONFIG_CONTENT" ]; then
+    echo "$TELEGRAF_CONFIG_CONTENT" > "/etc/telegraf/telegraf.conf"
+fi
+
 if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi

--- a/telegraf/1.12/entrypoint.sh
+++ b/telegraf/1.12/entrypoint.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -e
 
+
+# You can also set the TELEGRAF_CONFIG_CONTENT environment variable to pass some
+# Telegraf configuration without having to bind any volumes.
+# This is very usefull within kuberentes: the problem of using configmaps is that 
+# a change to a config doesn't restart telegraf
+if [ -n "$TELEGRAF_CONFIG_CONTENT" ]; then
+    echo "$TELEGRAF_CONFIG_CONTENT" > "/etc/telegraf/telegraf.conf"
+fi
+
 if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi


### PR DESCRIPTION
This feature will enable setting the telegraf config directly into an environment variable

very usefull when deploying this within kubernetes

I didn't backport this feature to 1.11/1.10 to force people to upgrade if they want this feature

Hashicorp Vault has the same setup https://github.com/hashicorp/docker-vault/blob/931be649e18a93b84da9c69ebbf41aaca5213090/0.X/docker-entrypoint.sh