### PR TITLE
Telegraf 1.13.0-rc1

### DIFF
--- a/telegraf/1.13/Dockerfile
+++ b/telegraf/1.13/Dockerfile
@@ -1,0 +1,35 @@
+FROM buildpack-deps:stretch-curl
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -ex && \
+    for key in \
+        05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
+    do \
+        gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+        gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
+        gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
+    done
+
+ENV TELEGRAF_VERSION 1.13.0~rc1
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
+    case "${dpkgArch##*-}" in \
+      amd64) ARCH='amd64';; \
+      arm64) ARCH='arm64';; \
+      armhf) ARCH='armhf';; \
+      armel) ARCH='armel';; \
+      *)     echo "Unsupported architecture: ${dpkgArch}"; exit 1;; \
+    esac && \
+    wget --no-verbose https://dl.influxdata.com/telegraf/releases/telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb.asc && \
+    wget --no-verbose https://dl.influxdata.com/telegraf/releases/telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb && \
+    gpg --batch --verify telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb.asc telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb && \
+    dpkg -i telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb && \
+    rm -f telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb*
+
+EXPOSE 8125/udp 8092/udp 8094
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["telegraf"]

--- a/telegraf/1.13/alpine/Dockerfile
+++ b/telegraf/1.13/alpine/Dockerfile
@@ -1,0 +1,33 @@
+FROM alpine:3.9
+
+RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata && \
+    update-ca-certificates
+
+ENV TELEGRAF_VERSION 1.13.0~rc1
+
+RUN set -ex && \
+    apk add --no-cache --virtual .build-deps wget gnupg tar && \
+    for key in \
+        05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
+    do \
+        gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+        gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
+        gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
+    done && \
+    wget --no-verbose https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}-static_linux_amd64.tar.gz.asc && \
+    wget --no-verbose https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}-static_linux_amd64.tar.gz && \
+    gpg --batch --verify telegraf-${TELEGRAF_VERSION}-static_linux_amd64.tar.gz.asc telegraf-${TELEGRAF_VERSION}-static_linux_amd64.tar.gz && \
+    mkdir -p /usr/src /etc/telegraf && \
+    tar -C /usr/src -xzf telegraf-${TELEGRAF_VERSION}-static_linux_amd64.tar.gz && \
+    mv /usr/src/telegraf*/telegraf.conf /etc/telegraf/ && \
+    chmod +x /usr/src/telegraf*/* && \
+    cp -a /usr/src/telegraf*/* /usr/bin/ && \
+    rm -rf *.tar.gz* /usr/src /root/.gnupg && \
+    apk del .build-deps
+
+EXPOSE 8125/udp 8092/udp 8094
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["telegraf"]

--- a/telegraf/1.13/alpine/entrypoint.sh
+++ b/telegraf/1.13/alpine/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+    set -- telegraf "$@"
+fi
+
+exec "$@"

--- a/telegraf/1.13/entrypoint.sh
+++ b/telegraf/1.13/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+    set -- telegraf "$@"
+fi
+
+exec "$@"

--- a/telegraf/manifest.json
+++ b/telegraf/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "telegraf",
-  "versions": ["1.10", "1.11", "1.12"],
+  "versions": ["1.11", "1.12", "1.13"],
   "architectures": [
     "amd64",
     "arm32v7",


### PR DESCRIPTION
Docker images of Telegraf release candidates isn't something we have done in the past, but has always been a requested feature.  Since we haven't done this before, I'm not sure if this PR is sufficient, or if we would need to take some extra steps.