### PR TITLE
Container migration to PhotonOS 3.0

### DIFF
--- a/telegraf/1.13/photon/Dockerfile
+++ b/telegraf/1.13/photon/Dockerfile
@@ -1,0 +1,33 @@
+FROM photon:3.0
+
+RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
+RUN tdnf update -y && tdnf upgrade -y && \
+    tdnf install -y shadow wget gzip gnupg tar openssl-c_rehash iputils ca-certificates net-snmp-tools procps lm_sensors tzdata 
+
+ENV TELEGRAF_VERSION 1.13.2
+
+RUN set -ex && \
+    for key in \
+        05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
+    do \
+        gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+        gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
+        gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
+    done && \
+    wget --no-verbose https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}-static_linux_amd64.tar.gz.asc && \
+    wget --no-verbose https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}-static_linux_amd64.tar.gz && \
+    gpg --batch --verify telegraf-${TELEGRAF_VERSION}-static_linux_amd64.tar.gz.asc telegraf-${TELEGRAF_VERSION}-static_linux_amd64.tar.gz && \
+    mkdir -p /usr/src /etc/telegraf && \
+    tar -C /usr/src -xzf telegraf-${TELEGRAF_VERSION}-static_linux_amd64.tar.gz && \
+    mv /usr/src/telegraf*/telegraf.conf /etc/telegraf/ && \
+    chmod +x /usr/src/telegraf*/* && \
+    cp -a /usr/src/telegraf*/* /usr/bin/ && \
+    rm -rf *.tar.gz* /usr/src /root/.gnupg
+
+EXPOSE 8125/udp 8092/udp 8094
+
+COPY entrypoint.sh /entrypoint.sh
+RUN useradd -m telegraf && chown telegraf:root /entrypoint.sh
+USER telegraf
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["telegraf"]

--- a/telegraf/1.13/photon/entrypoint.sh
+++ b/telegraf/1.13/photon/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+    set -- telegraf "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Twislock vulnerability scanner found numerous issues with the alpine build
also container must run as non root