### PR TITLE
Allow influxdb to run as a configurable uid/gid

### DIFF
--- a/influxdb/1.8/Dockerfile
+++ b/influxdb/1.8/Dockerfile
@@ -2,7 +2,7 @@ FROM buildpack-deps:stretch-curl
 
 RUN set -ex && \
     for key in \
-        05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
+        05CE15085FC09D18E99EFB22684A14CF2582E0C5 B42F6819007F00F88E364FD4036A9C25BF357DD4 ; \
     do \
         gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
@@ -10,6 +10,7 @@ RUN set -ex && \
     done
 
 ENV INFLUXDB_VERSION 1.8.0
+ENV GOSU_VERSION 1.12
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     case "${dpkgArch##*-}" in \
       amd64) ARCH='amd64';; \
@@ -22,7 +23,14 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb_${INFLUXDB_VERSION}_${ARCH}.deb && \
     gpg --batch --verify influxdb_${INFLUXDB_VERSION}_${ARCH}.deb.asc influxdb_${INFLUXDB_VERSION}_${ARCH}.deb && \
     dpkg -i influxdb_${INFLUXDB_VERSION}_${ARCH}.deb && \
-    rm -f influxdb_${INFLUXDB_VERSION}_${ARCH}.deb*
+    rm -f influxdb_${INFLUXDB_VERSION}_${ARCH}.deb* && \
+    wget --no-verbose https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${ARCH}.asc && \
+    wget --no-verbose https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${ARCH} && \
+    gpg --batch --verify gosu-${ARCH}.asc gosu-${ARCH} && \
+    rm -f gosu-${ARCH}.asc && \
+    mv gosu-${ARCH} /usr/local/bin && \
+    chmod +x /usr/local/bin/gosu-${ARCH} && \
+    ln -s /usr/local/bin/gosu-${ARCH} /usr/local/bin/gosu
 COPY influxdb.conf /etc/influxdb/influxdb.conf
 
 EXPOSE 8086

--- a/influxdb/1.8/entrypoint.sh
+++ b/influxdb/1.8/entrypoint.sh
@@ -18,7 +18,7 @@ if [ $GROUP_ID != 0 ]; then
   fi
 fi
 
-if [ $USER_ID != 0 -a $(stat -c "%u" /var/lib/influxdb) != $USER_ID ]; then
+if [ $USER_ID != 0 ]; then
   echo "Changing ownership of /var/lib/influxdb to $USER_ID:$GROUP_ID"
   chown -R ${USER_ID}:${GROUP_ID} /var/lib/influxdb
 fi
@@ -30,7 +30,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 if [ "$1" = 'influxd' ]; then
-	/init-influxdb.sh "${@:2}"
+    /init-influxdb.sh "${@:2}"
 fi
 
 if [ $USER_ID != 0 ]; then

--- a/influxdb/1.8/entrypoint.sh
+++ b/influxdb/1.8/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-USER_ID=${USER_ID:-0}
-GROUP_ID=${GROUP_ID:-0}
+USER_ID=${INFLUXDB_RUNAS_USER_ID:-0}
+GROUP_ID=${INFLUXDB_RUNAS_GROUP_ID:-0}
 
 if [ $USER_ID != 0 ]; then
   if [ $USER_ID != $(id -u influxdb) ]; then

--- a/influxdb/1.8/entrypoint.sh
+++ b/influxdb/1.8/entrypoint.sh
@@ -23,6 +23,12 @@ if [ $USER_ID != 0 ]; then
   chown -R ${USER_ID}:${GROUP_ID} /var/lib/influxdb
 fi
 
+if [ $USER_ID != 0 ]; then
+    GOSU_CMD="gosu influxdb"
+else
+    GOSU_CMD=
+fi
+
 echo "Starting influxdb as uid $USER_ID and gid $GROUP_ID"
 
 if [ "${1:0:1}" = '-' ]; then
@@ -30,11 +36,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 if [ "$1" = 'influxd' ]; then
-    /init-influxdb.sh "${@:2}"
+    $GOSU_CMD /init-influxdb.sh "${@:2}"
 fi
 
-if [ $USER_ID != 0 ]; then
-    exec gosu influxdb "$@"
-else
-    exec "$@"
-fi
+exec $GOSU_CMD "$@"

--- a/influxdb/1.8/entrypoint.sh
+++ b/influxdb/1.8/entrypoint.sh
@@ -33,4 +33,8 @@ if [ "$1" = 'influxd' ]; then
 	/init-influxdb.sh "${@:2}"
 fi
 
-exec gosu influxdb "$@"
+if [ $USER_ID != 0 ]; then
+    exec gosu influxdb "$@"
+else
+    exec "$@"
+fi

--- a/influxdb/1.8/entrypoint.sh
+++ b/influxdb/1.8/entrypoint.sh
@@ -1,6 +1,30 @@
 #!/bin/bash
 set -e
 
+USER_ID=${USER_ID:-0}
+GROUP_ID=${GROUP_ID:-0}
+
+if [ $USER_ID != 0 ]; then
+  if [ $USER_ID != $(id -u influxdb) ]; then
+    echo "Changing uid of influxdb to $USER_ID"
+    usermod -u $USER_ID influxdb
+  fi
+fi
+
+if [ $GROUP_ID != 0 ]; then
+  if [ $GROUP_ID != $(id -g influxdb) ]; then
+    echo "Changing gid of influxdb to $GROUP_ID"
+    groupmod -o -g $GROUP_ID influxdb
+  fi
+fi
+
+if [ $USER_ID != 0 -a $(stat -c "%u" /var/lib/influxdb) != $USER_ID ]; then
+  echo "Changing ownership of /var/lib/influxdb to $USER_ID:$GROUP_ID"
+  chown -R ${USER_ID}:${GROUP_ID} /var/lib/influxdb
+fi
+
+echo "Starting influxdb as uid $USER_ID and gid $GROUP_ID"
+
 if [ "${1:0:1}" = '-' ]; then
     set -- influxd "$@"
 fi
@@ -9,4 +33,4 @@ if [ "$1" = 'influxd' ]; then
 	/init-influxdb.sh "${@:2}"
 fi
 
-exec "$@"
+exec gosu influxdb "$@"


### PR DESCRIPTION
I wanted to configure `influxdb` to run under a particular uid/gid (non-root) that was different than 999:999 that comes pre-configured in the container. Using `--user` with docker didn't yield the desired results as it ended up not having permissions to access the data volume I supplied. 

With this change `entrypoint.sh` still runs as root and sets things up if `INFLUXDB_RUNAS_USER_ID` and `INFLUXDB_RUNAS_GROUP_ID` variables are provided. After that, it uses `gosu` (if applicable) to correctly downgrade to the influxdb user and group (now set to the correct uid/gid) before running `influxdb`.

I did some local testing, but being my first attempt at a contribution, I'd love to hear more about how to validate this change further. 