### PR TITLE
Added aarch64 support to alpine Dockerfile

### DIFF
--- a/influxdb/1.7/alpine/Dockerfile
+++ b/influxdb/1.7/alpine/Dockerfile
@@ -5,7 +5,17 @@ RUN apk add --no-cache tzdata bash ca-certificates && \
     update-ca-certificates
 
 ENV INFLUXDB_VERSION 1.7.10
-RUN set -ex && \
+RUN ARCH= && STATIC= && BINLOC= && \
+    unameArch="$(uname -m)" && \
+    case "${unameArch##*-}" in \
+      x86_64) ARCH='amd64';; \
+      aarch64) ARCH='arm64';; \
+      armv7l) ARCH='armhf';; \
+      *)     echo "Unsupported architecture: ${unameArch}"; exit 1;; \
+    esac && \
+    if [ "$ARCH" == "amd64" ]; then STATIC="-static"; fi && \
+    if [ "$ARCH" == "arm64" ] || [ "$ARCH" == "armhf" ]; then BINLOC="usr/bin/"; fi && \
+    set -ex && \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
@@ -14,14 +24,14 @@ RUN set -ex && \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
     done && \
-    wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb-${INFLUXDB_VERSION}-static_linux_amd64.tar.gz.asc && \
-    wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb-${INFLUXDB_VERSION}-static_linux_amd64.tar.gz && \
-    gpg --batch --verify influxdb-${INFLUXDB_VERSION}-static_linux_amd64.tar.gz.asc influxdb-${INFLUXDB_VERSION}-static_linux_amd64.tar.gz && \
+    wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb-${INFLUXDB_VERSION}${STATIC}_linux_${ARCH}.tar.gz.asc && \
+    wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb-${INFLUXDB_VERSION}${STATIC}_linux_${ARCH}.tar.gz && \
+    gpg --batch --verify influxdb-${INFLUXDB_VERSION}${STATIC}_linux_${ARCH}.tar.gz.asc influxdb-${INFLUXDB_VERSION}${STATIC}_linux_${ARCH}.tar.gz && \
     mkdir -p /usr/src && \
-    tar -C /usr/src -xzf influxdb-${INFLUXDB_VERSION}-static_linux_amd64.tar.gz && \
+    tar -C /usr/src -xzf influxdb-${INFLUXDB_VERSION}${STATIC}_linux_${ARCH}.tar.gz && \
     rm -f /usr/src/influxdb-*/influxdb.conf && \
     chmod +x /usr/src/influxdb-*/* && \
-    cp -a /usr/src/influxdb-*/* /usr/bin/ && \
+    cp -a /usr/src/influxdb-*/${BINLOC}* /usr/bin/ && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \
     apk del .build-deps
 COPY influxdb.conf /etc/influxdb/influxdb.conf

--- a/influxdb/1.8/alpine/Dockerfile
+++ b/influxdb/1.8/alpine/Dockerfile
@@ -5,7 +5,17 @@ RUN apk add --no-cache tzdata bash ca-certificates && \
     update-ca-certificates
 
 ENV INFLUXDB_VERSION 1.8.0
-RUN set -ex && \
+RUN ARCH= && STATIC= && BINLOC= && \
+    unameArch="$(uname -m)" && \
+    case "${unameArch##*-}" in \
+      x86_64) ARCH='amd64';; \
+      aarch64) ARCH='arm64';; \
+      armv7l) ARCH='armhf';; \
+      *)     echo "Unsupported architecture: ${unameArch}"; exit 1;; \
+    esac && \
+    if [ "$ARCH" == "amd64" ]; then STATIC="-static"; fi && \
+    if [ "$ARCH" == "arm64" ] || [ "$ARCH" == "armhf" ]; then BINLOC="usr/bin/"; fi && \
+    set -ex && \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \
     for key in \
         05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
@@ -14,14 +24,12 @@ RUN set -ex && \
         gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
     done && \
-    wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb-${INFLUXDB_VERSION}-static_linux_amd64.tar.gz.asc && \
-    wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb-${INFLUXDB_VERSION}-static_linux_amd64.tar.gz && \
-    gpg --batch --verify influxdb-${INFLUXDB_VERSION}-static_linux_amd64.tar.gz.asc influxdb-${INFLUXDB_VERSION}-static_linux_amd64.tar.gz && \
+    wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb-${INFLUXDB_VERSION}${STATIC}_linux_${ARCH}.tar.gz.asc && \
+    wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb-${INFLUXDB_VERSION}${STATIC}_linux_${ARCH}.tar.gz && \
+    gpg --batch --verify influxdb-${INFLUXDB_VERSION}${STATIC}_linux_${ARCH}.tar.gz.asc influxdb-${INFLUXDB_VERSION}${STATIC}_linux_${ARCH}.tar.gz && \
     mkdir -p /usr/src && \
-    tar -C /usr/src -xzf influxdb-${INFLUXDB_VERSION}-static_linux_amd64.tar.gz && \
-    rm -f /usr/src/influxdb-*/influxdb.conf && \
-    chmod +x /usr/src/influxdb-*/* && \
-    cp -a /usr/src/influxdb-*/* /usr/bin/ && \
+    tar -C /usr/src -xzf influxdb-${INFLUXDB_VERSION}${STATIC}_linux_${ARCH}.tar.gz && \
+    cp -a /usr/src/influxdb-*/${BINLOC}* /usr/bin/ && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \
     apk del .build-deps
 COPY influxdb.conf /etc/influxdb/influxdb.conf


### PR DESCRIPTION
Addresses issue [#335 ](https://github.com/influxdata/influxdata-docker/issues/335) and #269 .

The Dockerfile can be simplified if the way the release binaries are packaged is also simplified/updated. 

The alpine Dockerfile uses the statically compiled version of the binary. For version 1.8.0 on x86_64 (a.k.a. amd64), this would be influxdb-1.8.0-static_linux_amd64.tar.gz. However, for aarch64 (a.k.a. arm64) the statically compiled version is called influxdb-1.8.0_linux_arm64.tar.gz. The omission of the characters "-static" means we need to handle this difference in the Dockerfile. There doesn't appear to be a dynamically linked version of the binary for aarch64.

Further, the location of where the binaries are located between x86_64 and aarch64 is different. Hence the use of the BINLOC variable to deal with this difference. In the influxdb-1.8.0-static_linux_amd64.tar.gz file for x86_64, the statically compiled binaries are in the root directory once this file is untarred. In the influxdb-1.8.0-linux_arm64.tar.gz for aarch64, the statically compiled binaries are in usr/bin once the file is untarred. Basically, there is an inconsistency on where the statically compiled binaries are located in the release tarballs.

Last, just as an FYI, if you look at the dynamically linked version for x86_64, you'll noticed that the binaries for these is under location usr/bin after you untar influxdb-1.8.0-linux_amd64.tar.gz.

If the binary packaging noted above is made more consistent between x86_64 and aarch64, the Dockerfiles would not have to require the STATIC or BINLOC variables.