### PR TITLE
feat: use Makefile and CircleCI matrix jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,4 +43,4 @@ workflows:
             parameters:
               image: ["telegraf"]
               variant: ["debian", "alpine"]
-              version: ["1.12.6", "1.13.4", "1.14.2"]
+              version: ["1.12.6", "1.13.4", "1.14.3"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,46 @@
-version: 2
+version: 2.1
 jobs:
-  build:
+  build-image:
+    parameters:
+      image:
+        type: string
+      variant:
+        type: string
+      version:
+        type: string
     docker:
       - image: circleci/golang:1.11
     working_directory: /go/src/github.com/influxdata/influxdata-docker
     steps:
       - checkout
-      - setup_remote_docker
-      - run: bash circle-test.sh
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - run: make build-image IMAGE=<< parameters.image >> VARIANT=<< parameters.variant >> VERSION=<< parameters.version >>
+  
+workflows:
+  build-image:
+    jobs:
+      - build-image:
+          matrix:
+            parameters:
+              image: ["chronograf"]
+              variant: ["debian", "alpine"]
+              version: ["1.6.2", "1.7.17", "1.8.4"]
+      - build-image:
+          matrix:
+            parameters:
+              image: ["influxdb"]
+              variant: ["debian", "alpine"]
+              version: ["1.7.10", "1.8.0", "nightly"]
+      - build-image:
+          matrix:
+            parameters:
+              image: ["kapacitor"]
+              variant: ["debian", "alpine"]
+              version: ["1.4.1", "1.5.4"]
+      - build-image:
+          matrix:
+            parameters:
+              image: ["telegraf"]
+              variant: ["debian", "alpine"]
+              version: ["1.12.6", "1.13.4", "1.14.2"]

--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ CONTEXT=./$(IMAGE)/$(MAJORMINORVERSION)/$(VARIANT)
 endif
 
 build-image:
-	@docker image build --no-cache -f $(CONTEXT)/Dockerfile $(CONTEXT)
+	@docker image build --build-arg VERSION=$(VERSION) --no-cache -f $(CONTEXT)/Dockerfile $(CONTEXT)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+ifndef IMAGE
+$(error IMAGE is not set)
+endif
+
+ifndef VARIANT
+$(error VARIANT is not set)
+endif
+
+ifndef VERSION
+$(error VERSION is not set)
+endif
+
+# This works for `nightly` too, as it doesn't match semver format and won't be modified
+MAJORMINORVERSION=$(shell echo $(VERSION) | perl -pe  's/^(\d+)\.(\d+)\.(\d+)$$/$$1.$$2/g')
+
+ifeq ($(VARIANT), debian)
+CONTEXT=./$(IMAGE)/$(MAJORMINORVERSION)
+else
+CONTEXT=./$(IMAGE)/$(MAJORMINORVERSION)/$(VARIANT)
+endif
+
+build-image:
+	@docker image build --no-cache -f $(CONTEXT)/Dockerfile $(CONTEXT)

--- a/chronograf/1.6/Dockerfile
+++ b/chronograf/1.6/Dockerfile
@@ -11,7 +11,9 @@ RUN set -ex && \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
     done
 
-ENV CHRONOGRAF_VERSION 1.6.2
+ARG VERSION
+ENV CHRONOGRAF_VERSION ${VERSION}
+
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     case "${dpkgArch##*-}" in \
       amd64) ARCH='amd64';; \

--- a/chronograf/1.6/alpine/Dockerfile
+++ b/chronograf/1.6/alpine/Dockerfile
@@ -4,7 +4,8 @@ RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \
     update-ca-certificates
 
-ENV CHRONOGRAF_VERSION 1.6.2
+ARG VERSION
+ENV CHRONOGRAF_VERSION ${VERSION}
 
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \

--- a/chronograf/1.7/Dockerfile
+++ b/chronograf/1.7/Dockerfile
@@ -11,7 +11,9 @@ RUN set -ex && \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
     done
 
-ENV CHRONOGRAF_VERSION 1.7.17
+ARG VERSION
+ENV CHRONOGRAF_VERSION ${VERSION}
+
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     case "${dpkgArch##*-}" in \
       amd64) ARCH='amd64';; \

--- a/chronograf/1.7/alpine/Dockerfile
+++ b/chronograf/1.7/alpine/Dockerfile
@@ -4,7 +4,8 @@ RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \
     update-ca-certificates
 
-ENV CHRONOGRAF_VERSION 1.7.17
+ARG VERSION
+ENV CHRONOGRAF_VERSION ${VERSION}
 
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \

--- a/chronograf/1.8/Dockerfile
+++ b/chronograf/1.8/Dockerfile
@@ -11,7 +11,9 @@ RUN set -ex && \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
     done
 
-ENV CHRONOGRAF_VERSION 1.8.4
+ARG VERSION
+ENV CHRONOGRAF_VERSION ${VERSION}
+
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     case "${dpkgArch##*-}" in \
       amd64) ARCH='amd64';; \

--- a/chronograf/1.8/alpine/Dockerfile
+++ b/chronograf/1.8/alpine/Dockerfile
@@ -4,7 +4,8 @@ RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \
     update-ca-certificates
 
-ENV CHRONOGRAF_VERSION 1.8.4
+ARG VERSION
+ENV CHRONOGRAF_VERSION ${VERSION}
 
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \

--- a/influxdb/1.7/Dockerfile
+++ b/influxdb/1.7/Dockerfile
@@ -9,7 +9,9 @@ RUN set -ex && \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
     done
 
-ENV INFLUXDB_VERSION 1.7.10
+ARG VERSION
+ENV INFLUXDB_VERSION ${VERSION}
+
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     case "${dpkgArch##*-}" in \
       amd64) ARCH='amd64';; \

--- a/influxdb/1.7/alpine/Dockerfile
+++ b/influxdb/1.7/alpine/Dockerfile
@@ -4,7 +4,9 @@ RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \
     update-ca-certificates
 
-ENV INFLUXDB_VERSION 1.7.10
+ARG VERSION
+ENV INFLUXDB_VERSION ${VERSION}
+
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \
     for key in \

--- a/influxdb/1.8/Dockerfile
+++ b/influxdb/1.8/Dockerfile
@@ -9,7 +9,9 @@ RUN set -ex && \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
     done
 
-ENV INFLUXDB_VERSION 1.8.0
+ARG VERSION
+ENV INFLUXDB_VERSION ${VERSION}
+
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     case "${dpkgArch##*-}" in \
       amd64) ARCH='amd64';; \

--- a/influxdb/1.8/alpine/Dockerfile
+++ b/influxdb/1.8/alpine/Dockerfile
@@ -4,7 +4,9 @@ RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \
     update-ca-certificates
 
-ENV INFLUXDB_VERSION 1.8.0
+ARG VERSION
+ENV INFLUXDB_VERSION ${VERSION}
+
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \
     for key in \

--- a/kapacitor/1.4/Dockerfile
+++ b/kapacitor/1.4/Dockerfile
@@ -14,7 +14,9 @@ RUN set -ex && \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
     done
 
-ENV KAPACITOR_VERSION 1.4.1
+ARG VERSION
+ENV KAPACITOR_VERSION ${VERSION}
+
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     case "${dpkgArch##*-}" in \
       amd64) ARCH='amd64';; \

--- a/kapacitor/1.4/alpine/Dockerfile
+++ b/kapacitor/1.4/alpine/Dockerfile
@@ -4,7 +4,8 @@ RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \
     update-ca-certificates
 
-ENV KAPACITOR_VERSION 1.4.1
+ARG VERSION
+ENV KAPACITOR_VERSION ${VERSION}
 
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \

--- a/kapacitor/1.5/Dockerfile
+++ b/kapacitor/1.5/Dockerfile
@@ -14,7 +14,9 @@ RUN set -ex && \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
     done
 
-ENV KAPACITOR_VERSION 1.5.4
+ARG VERSION
+ENV KAPACITOR_VERSION ${VERSION}
+
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     case "${dpkgArch##*-}" in \
       amd64) ARCH='amd64';; \

--- a/kapacitor/1.5/alpine/Dockerfile
+++ b/kapacitor/1.5/alpine/Dockerfile
@@ -4,7 +4,8 @@ RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \
     update-ca-certificates
 
-ENV KAPACITOR_VERSION 1.5.4
+ARG VERSION
+ENV KAPACITOR_VERSION ${VERSION}
 
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \

--- a/telegraf/1.12/Dockerfile
+++ b/telegraf/1.12/Dockerfile
@@ -13,7 +13,9 @@ RUN set -ex && \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
     done
 
-ENV TELEGRAF_VERSION 1.12.6
+ARG VERSION
+ENV TELEGRAF_VERSION ${VERSION}
+
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     case "${dpkgArch##*-}" in \
       amd64) ARCH='amd64';; \

--- a/telegraf/1.12/alpine/Dockerfile
+++ b/telegraf/1.12/alpine/Dockerfile
@@ -4,7 +4,8 @@ RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata && \
     update-ca-certificates
 
-ENV TELEGRAF_VERSION 1.12.6
+ARG VERSION
+ENV TELEGRAF_VERSION ${VERSION}
 
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \

--- a/telegraf/1.13/Dockerfile
+++ b/telegraf/1.13/Dockerfile
@@ -13,7 +13,9 @@ RUN set -ex && \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
     done
 
-ENV TELEGRAF_VERSION 1.13.4
+ARG VERSION
+ENV TELEGRAF_VERSION ${VERSION}
+
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     case "${dpkgArch##*-}" in \
       amd64) ARCH='amd64';; \

--- a/telegraf/1.13/alpine/Dockerfile
+++ b/telegraf/1.13/alpine/Dockerfile
@@ -4,7 +4,8 @@ RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata && \
     update-ca-certificates
 
-ENV TELEGRAF_VERSION 1.13.4
+ARG VERSION
+ENV TELEGRAF_VERSION ${VERSION}
 
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \

--- a/telegraf/1.14/Dockerfile
+++ b/telegraf/1.14/Dockerfile
@@ -13,7 +13,9 @@ RUN set -ex && \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
     done
 
-ENV TELEGRAF_VERSION 1.14.3
+ARG VERSION
+ENV TELEGRAF_VERSION ${VERSION}
+
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     case "${dpkgArch##*-}" in \
       amd64) ARCH='amd64';; \

--- a/telegraf/1.14/alpine/Dockerfile
+++ b/telegraf/1.14/alpine/Dockerfile
@@ -4,7 +4,8 @@ RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata && \
     update-ca-certificates
 
-ENV TELEGRAF_VERSION 1.14.3
+ARG VERSION
+ENV TELEGRAF_VERSION ${VERSION}
 
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \


### PR DESCRIPTION
Why should we merge this?

- Only need to update the versions in the CircleCI file
- Can retry individual failing builds
- Can be run locally using `make`

This PR leverages CircleCI's matrix job workflows to allow each image to be build individually, which should allow for failing jobs (due to external connections) to be retried without running every single image again.

**Potential Future PRs**

Highest value:

Remove directories for each version. I don't believe these are actually required

Others:
- Have Jenkins use the same approach
- Multistage builds for building products from source instead of using precompiled binaries
