### PR TITLE
Shutdown gpg background tasks in alpine image

### DIFF
--- a/chronograf/1.6/alpine/Dockerfile
+++ b/chronograf/1.6/alpine/Dockerfile
@@ -23,6 +23,7 @@ RUN set -ex && \
     rm -f /usr/src/chronograf-*/chronograf.conf && \
     chmod +x /usr/src/chronograf-*/* && \
     cp -a /usr/src/chronograf-*/* /usr/bin/ && \
+    gpgconf --kill all && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \
     apk del .build-deps
 

--- a/chronograf/1.7/alpine/Dockerfile
+++ b/chronograf/1.7/alpine/Dockerfile
@@ -23,6 +23,7 @@ RUN set -ex && \
     rm -f /usr/src/chronograf-*/chronograf.conf && \
     chmod +x /usr/src/chronograf-*/* && \
     cp -a /usr/src/chronograf-*/* /usr/bin/ && \
+    gpgconf --kill all && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \
     apk del .build-deps
 

--- a/chronograf/1.8/alpine/Dockerfile
+++ b/chronograf/1.8/alpine/Dockerfile
@@ -23,6 +23,7 @@ RUN set -ex && \
     rm -f /usr/src/chronograf-*/chronograf.conf && \
     chmod +x /usr/src/chronograf-*/* && \
     cp -a /usr/src/chronograf-*/* /usr/bin/ && \
+    gpgconf --kill all && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \
     apk del .build-deps
 

--- a/influxdb/1.7/alpine/Dockerfile
+++ b/influxdb/1.7/alpine/Dockerfile
@@ -22,6 +22,7 @@ RUN set -ex && \
     rm -f /usr/src/influxdb-*/influxdb.conf && \
     chmod +x /usr/src/influxdb-*/* && \
     cp -a /usr/src/influxdb-*/* /usr/bin/ && \
+    gpgconf --kill all && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \
     apk del .build-deps
 COPY influxdb.conf /etc/influxdb/influxdb.conf

--- a/influxdb/1.8/alpine/Dockerfile
+++ b/influxdb/1.8/alpine/Dockerfile
@@ -22,6 +22,7 @@ RUN set -ex && \
     rm -f /usr/src/influxdb-*/influxdb.conf && \
     chmod +x /usr/src/influxdb-*/* && \
     cp -a /usr/src/influxdb-*/* /usr/bin/ && \
+    gpgconf --kill all && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \
     apk del .build-deps
 COPY influxdb.conf /etc/influxdb/influxdb.conf

--- a/influxdb/nightly/alpine/Dockerfile
+++ b/influxdb/nightly/alpine/Dockerfile
@@ -20,6 +20,7 @@ RUN set -ex && \
     rm -f /usr/src/influxdb-*/influxdb.conf && \
     chmod +x /usr/src/influxdb-*/* && \
     cp -a /usr/src/influxdb-*/* /usr/bin/ && \
+    gpgconf --kill all && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \
     apk del .build-deps
 COPY influxdb.conf /etc/influxdb/influxdb.conf

--- a/kapacitor/1.4/alpine/Dockerfile
+++ b/kapacitor/1.4/alpine/Dockerfile
@@ -23,6 +23,7 @@ RUN set -ex && \
     rm -f /usr/src/kapacitor-*/kapacitor.conf && \
     chmod +x /usr/src/kapacitor-*/* && \
     cp -a /usr/src/kapacitor-*/* /usr/bin/ && \
+    gpgconf --kill all && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \
     apk del .build-deps
 COPY kapacitor.conf /etc/kapacitor/kapacitor.conf

--- a/kapacitor/1.5/alpine/Dockerfile
+++ b/kapacitor/1.5/alpine/Dockerfile
@@ -23,6 +23,7 @@ RUN set -ex && \
     rm -f /usr/src/kapacitor-*/kapacitor.conf && \
     chmod +x /usr/src/kapacitor-*/* && \
     cp -a /usr/src/kapacitor-*/* /usr/bin/ && \
+    gpgconf --kill all && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \
     apk del .build-deps
 COPY kapacitor.conf /etc/kapacitor/kapacitor.conf

--- a/telegraf/1.12/alpine/Dockerfile
+++ b/telegraf/1.12/alpine/Dockerfile
@@ -23,6 +23,7 @@ RUN set -ex && \
     mv /usr/src/telegraf*/telegraf.conf /etc/telegraf/ && \
     chmod +x /usr/src/telegraf*/* && \
     cp -a /usr/src/telegraf*/* /usr/bin/ && \
+    gpgconf --kill all && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \
     apk del .build-deps
 

--- a/telegraf/1.13/alpine/Dockerfile
+++ b/telegraf/1.13/alpine/Dockerfile
@@ -23,6 +23,7 @@ RUN set -ex && \
     mv /usr/src/telegraf*/telegraf.conf /etc/telegraf/ && \
     chmod +x /usr/src/telegraf*/* && \
     cp -a /usr/src/telegraf*/* /usr/bin/ && \
+    gpgconf --kill all && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \
     apk del .build-deps
 

--- a/telegraf/1.14/alpine/Dockerfile
+++ b/telegraf/1.14/alpine/Dockerfile
@@ -23,6 +23,7 @@ RUN set -ex && \
     mv /usr/src/telegraf*/telegraf.conf /etc/telegraf/ && \
     chmod +x /usr/src/telegraf*/* && \
     cp -a /usr/src/telegraf*/* /usr/bin/ && \
+    gpgconf --kill all && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \
     apk del .build-deps
 


### PR DESCRIPTION
As recommended by the Docker images team, use `gpgconf --kill all` to close all components running as daemons before we attempt to remove the ~/.gnupg directory.  This should avoid possible errors removing the directory.

I have tested the build of Telegraf 1.14 image.

ref: https://github.com/docker-library/official-images/pull/8159#issuecomment-641573393