### PR TITLE
Use the telegraf user created by the deb

### DIFF
--- a/telegraf/1.13/Dockerfile
+++ b/telegraf/1.13/Dockerfile
@@ -30,6 +30,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
 
 EXPOSE 8125/udp 8092/udp 8094
 
+USER telegraf
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["telegraf"]

--- a/telegraf/1.14/Dockerfile
+++ b/telegraf/1.14/Dockerfile
@@ -30,6 +30,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
 
 EXPOSE 8125/udp 8092/udp 8094
 
+USER telegraf
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["telegraf"]

--- a/telegraf/1.15/Dockerfile
+++ b/telegraf/1.15/Dockerfile
@@ -30,6 +30,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
 
 EXPOSE 8125/udp 8092/udp 8094
 
+USER telegraf
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["telegraf"]


### PR DESCRIPTION
Currently these containers run with the root user, which is not a good security practice.

The alpine containers do not have a `telegraf` user, should the `nobody` user be used instead, or add a step to create the user after the fetching and expanding the tar?