### PR TITLE
chore: kapacitor build to 1.5.6

### DIFF
--- a/kapacitor/1.5/Dockerfile
+++ b/kapacitor/1.5/Dockerfile
@@ -14,7 +14,7 @@ RUN set -ex && \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
     done
 
-ENV KAPACITOR_VERSION 1.5.5
+ENV KAPACITOR_VERSION 1.5.6
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     case "${dpkgArch##*-}" in \
       amd64) ARCH='amd64';; \

--- a/kapacitor/1.5/alpine/Dockerfile
+++ b/kapacitor/1.5/alpine/Dockerfile
@@ -4,7 +4,7 @@ RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \
     update-ca-certificates
 
-ENV KAPACITOR_VERSION 1.5.5
+ENV KAPACITOR_VERSION 1.5.6
 
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \


### PR DESCRIPTION
This will update the kap docker build to 1.5.6