### PR TITLE
Add official image for influxdb 2.0

### DIFF
--- a/influxdb/2.0/Dockerfile
+++ b/influxdb/2.0/Dockerfile
@@ -1,0 +1,36 @@
+FROM buildpack-deps:buster-curl
+
+# TODO(jsternberg): Download key from the keyserver once it is available.
+#RUN set -ex && \
+#    mkdir ~/.gnupg; \
+#    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 05CE15085FC09D18E99EFB22684A14CF2582E0C5
+RUN set -ex && \
+    mkdir ~/.gnupg; \
+    wget --no-verbose https://repos.influxdata.com/influxdb2.key && \
+    gpg --batch --import influxdb2.key && \
+    rm -f influxdb2.key
+
+ENV INFLUXDB_VERSION 2.0.0
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
+    case "${dpkgArch##*-}" in \
+      amd64) ARCH='amd64';; \
+      arm64) ARCH='arm64';; \
+      armhf) ARCH='armhf';; \
+      armel) ARCH='armel';; \
+      *)     echo "Unsupported architecture: ${dpkgArch}"; exit 1;; \
+    esac && \
+    wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb_${INFLUXDB_VERSION}_${ARCH}.deb.asc && \
+    wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb_${INFLUXDB_VERSION}_${ARCH}.deb && \
+    gpg --batch --verify influxdb_${INFLUXDB_VERSION}_${ARCH}.deb.asc influxdb_${INFLUXDB_VERSION}_${ARCH}.deb && \
+    dpkg -i influxdb_${INFLUXDB_VERSION}_${ARCH}.deb && \
+    rm -f influxdb_${INFLUXDB_VERSION}_${ARCH}.deb*
+COPY config.yml /etc/influxdb/config.yml
+ENV INFLUXD_CONFIG_PATH /etc/influxdb
+
+EXPOSE 8086
+
+VOLUME /var/lib/influxdb
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["influxd"]

--- a/influxdb/2.0/config.yml
+++ b/influxdb/2.0/config.yml
@@ -1,0 +1,2 @@
+bolt-path: /var/lib/influxdb/influxd.bolt
+engine-path: /var/lib/influxdb/engine

--- a/influxdb/2.0/entrypoint.sh
+++ b/influxdb/2.0/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+    set -- influxd "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
This contains the official image for influxdb 2.0 with the debian
package. The alpine image has not been done yet. The init script has
also not been created/ported (whichever is more appropriate). An upgrade
script from 1.x has also not been done.