### PR TITLE
Add ipmitool, smartmontools & nvme-cli to Debian

### DIFF
--- a/telegraf/1.16/Dockerfile
+++ b/telegraf/1.16/Dockerfile
@@ -2,6 +2,7 @@ FROM buildpack-deps:buster-curl
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y smartmontools ipmitool nvme-cli && \
     rm -rf /var/lib/apt/lists/*
 
 RUN set -ex && \


### PR DESCRIPTION
Every time my telegraf container at home updates I need to re-install these apps.  I am guessing I am not the only one.  They also do not take much room in the end so I think this is worth it for everyone.