### PR TITLE
Refactor manifests to support different arch/variants per version.

### DIFF
--- a/chronograf/manifest.json
+++ b/chronograf/manifest.json
@@ -4,13 +4,18 @@
     "Jonathan A. Sternberg <jonathan@influxdata.com> (@jsternberg)",
     "Bucky Schwarz <bucky@influxdata.com> (@hoorayimhelping)"
   ],
-  "versions": ["1.6", "1.7", "1.8"],
-  "architectures": [
-    "amd64",
-    "arm32v7",
-    "arm64v8"
-  ],
-  "variants": [
-    {"name": "alpine"}
+  "major-versions": [
+    {
+      "name": "1.x",
+      "versions": ["1.6", "1.7", "1.8"],
+      "architectures": [
+        "amd64",
+        "arm32v7",
+        "arm64v8"
+      ],
+      "variants": [
+        {"name": "alpine"}
+      ]
+    }
   ]
 }

--- a/dockerlib/commands.go
+++ b/dockerlib/commands.go
@@ -1,11 +1,9 @@
 package main
 
 import (
-	"os"
-
-	"path/filepath"
-
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/influxdata/influxdata-docker/dockerlib/dockerlib"
 	"github.com/spf13/cobra"
@@ -57,7 +55,7 @@ func Update() error {
 			}
 			defer f.Close()
 
-			if err := m.Write(f, &header); err != nil {
+			if err := m.Write(f, &header, dockerlib.DockerfileVersion); err != nil {
 				return err
 			}
 			return f.Close()

--- a/dockerlib/dockerlib/manifest.go
+++ b/dockerlib/dockerlib/manifest.go
@@ -12,13 +12,17 @@ import (
 )
 
 type ImageManifest struct {
-	Name          string     `json:"name"`
-	BaseDir       string     `json:"-"`
-	Maintainers   []string   `json:"maintainers"`
+	Name          string          `json:"name"`
+	BaseDir       string          `json:"-"`
+	Maintainers   []string        `json:"maintainers"`
+	MajorVersions []MajorVersions `json:"major-versions"`
+	Latest        string          `json:"-"`
+}
+
+type MajorVersions struct {
 	Versions      []*Version `json:"versions"`
 	Architectures []string   `json:"architectures"`
 	Variants      []*Variant `json:"variants"`
-	Latest        string     `json:"-"`
 }
 
 type Variant struct {
@@ -67,100 +71,118 @@ func ReadImageManifest(fpath string) (*ImageManifest, error) {
 	}
 	manifest.BaseDir = filepath.Dir(fpath)
 
+	if len(manifest.MajorVersions) == 0 {
+		return nil, fmt.Errorf("manifest for %q must have at least one major version", manifest.Name)
+	}
+
 	// Look through each of the versions to determine which is the latest.
-	if len(manifest.Versions) > 0 {
-		manifest.Latest = Versions(manifest.Versions).Latest().String()
+	var allVersions []*Version
+	for _, major := range manifest.MajorVersions {
+		if len(major.Versions) == 0 {
+			continue
+		}
+
+		allVersions = append(allVersions, major.Versions...)
+	}
+	if len(allVersions) > 0 {
+		manifest.Latest = Versions(allVersions).Latest().String()
 	}
 
 	// Propagate the image values to the variants and determine the base directory
 	// and the latest version.
-	for i, variant := range manifest.Variants {
-		if len(variant.Versions) == 0 {
-			manifest.Variants[i].Versions = manifest.Versions
-			manifest.Variants[i].Latest = manifest.Latest
-		} else {
-			manifest.Variants[i].Latest = Versions(variant.Versions).Latest().String()
+	for _, major := range manifest.MajorVersions {
+		for i, variant := range major.Variants {
+			if len(variant.Versions) == 0 {
+				major.Variants[i].Versions = major.Versions
+				major.Variants[i].Latest = manifest.Latest
+			} else {
+				major.Variants[i].Latest = Versions(variant.Versions).Latest().String()
+			}
 		}
 	}
+
 	return &manifest, nil
 }
 
-func (m *ImageManifest) Write(w io.Writer, header *Header) error {
+func (m *ImageManifest) Write(w io.Writer, header *Header, getFullVersion func(dir string) (*Version, error)) error {
 	// Output the initial header passed in to write.
 	if header != nil {
 		header.Write(w)
 	}
 
 	// Determine all of the versions.
-	for _, v := range m.Versions {
-		dir := filepath.Join(m.BaseDir, v.String())
-
-		header := &Header{}
-		version, err := DockerfileVersion(dir)
-		if err != nil {
-			return err
-		}
-		for i := 2; i <= len(version.Segments()); i++ {
-			segments := version.Segments()
-			parts := make([]string, i)
-			for j, s := range segments[:i] {
-				parts[j] = strconv.Itoa(s)
-			}
-			header.Add("Tags", strings.Join(parts, "."))
-		}
-		if m.Latest == v.String() {
-			header.Add("Tags", "latest")
-		}
-		for _, arch := range m.Architectures {
-			header.Add("Architectures", arch)
-		}
-		header.Add("Directory", dir)
-
-		fmt.Fprintln(w)
-		if err := header.Write(w); err != nil {
-			return err
-		}
-
-		for _, variant := range m.Variants {
-			// Check if this variant is included in the list of versions.
-			found := false
-			for _, vv := range variant.Versions {
-				if v.String() == vv.String() {
-					found = true
-					break
-				}
-			}
-
-			// Skip this variant if the version isn't found in the variant.
-			if !found {
-				continue
-			}
+	for _, mv := range m.MajorVersions {
+		for _, v := range mv.Versions {
+			dir := filepath.Join(m.BaseDir, v.String())
 
 			header := &Header{}
-			version, err := DockerfileVersion(dir)
+			version, err := getFullVersion(dir)
 			if err != nil {
 				return err
 			}
-			name := strings.Replace(variant.Name, "/", "-", -1)
 			for i := 2; i <= len(version.Segments()); i++ {
 				segments := version.Segments()
 				parts := make([]string, i)
 				for j, s := range segments[:i] {
 					parts[j] = strconv.Itoa(s)
 				}
-				header.Add("Tags", strings.Join(parts, ".")+"-"+name)
+				header.Add("Tags", strings.Join(parts, "."))
 			}
-			if variant.Latest == v.String() {
-				header.Add("Tags", name)
+			if m.Latest == v.String() {
+				header.Add("Tags", "latest")
 			}
-			for _, arch := range variant.Architectures {
+			for _, arch := range mv.Architectures {
 				header.Add("Architectures", arch)
 			}
-			header.Add("Directory", filepath.Join(dir, variant.Name))
-			//header.Add("Tags", variant.Name)
+			header.Add("Directory", dir)
+
 			fmt.Fprintln(w)
 			if err := header.Write(w); err != nil {
 				return err
+			}
+
+			for _, variant := range mv.Variants {
+				// Check if this variant is included in the list of versions.
+				found := false
+				for _, vv := range variant.Versions {
+					if v.String() == vv.String() {
+						found = true
+						break
+					}
+				}
+
+				// Skip this variant if the version isn't found in the variant.
+				if !found {
+					continue
+				}
+
+				header := &Header{}
+				vardir := filepath.Join(dir, variant.Name)
+				version, err := getFullVersion(vardir)
+				if err != nil {
+					return err
+				}
+				name := strings.Replace(variant.Name, "/", "-", -1)
+				for i := 2; i <= len(version.Segments()); i++ {
+					segments := version.Segments()
+					parts := make([]string, i)
+					for j, s := range segments[:i] {
+						parts[j] = strconv.Itoa(s)
+					}
+					header.Add("Tags", strings.Join(parts, ".")+"-"+name)
+				}
+				if variant.Latest == v.String() {
+					header.Add("Tags", name)
+				}
+				for _, arch := range variant.Architectures {
+					header.Add("Architectures", arch)
+				}
+				header.Add("Directory", vardir)
+				//header.Add("Tags", variant.Name)
+				fmt.Fprintln(w)
+				if err := header.Write(w); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/dockerlib/dockerlib/manifest_test.go
+++ b/dockerlib/dockerlib/manifest_test.go
@@ -1,0 +1,135 @@
+package dockerlib
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var exampleManifest = `{
+  "name": "influxdb",
+  "maintainers": ["Test Maintainer"],
+  "major-versions": [
+    {
+      "name": "1.x",
+      "versions": ["1.7", "1.8"],
+      "architectures": ["amd64", "arm32v7", "arm64v8"],
+      "variants": [
+        { "name": "alpine" },
+        { "name": "data" },
+        { "name": "data/alpine" },
+        { "name": "meta" },
+        { "name": "meta/alpine" }
+      ]
+    },
+    {
+      "name": "2.x",
+      "versions": ["2.0"],
+      "architectures": ["amd64", "arm64v8"],
+      "variants": [
+        { "name": "alpine" }
+      ]
+    }
+  ]
+}`
+
+var manifestVersions = map[string]string{
+	"influxdb/1.7": "1.7.10",
+	"influxdb/1.7/alpine": "1.7.10",
+	"influxdb/1.7/meta": "1.7.10",
+	"influxdb/1.7/meta/alpine": "1.7.10",
+	"influxdb/1.7/data": "1.7.10",
+	"influxdb/1.7/data/alpine": "1.7.10",
+	"influxdb/1.8": "1.8.3",
+	"influxdb/1.8/alpine": "1.8.3",
+	"influxdb/1.8/meta": "1.8.3",
+	"influxdb/1.8/meta/alpine": "1.8.3",
+	"influxdb/1.8/data": "1.8.3",
+	"influxdb/1.8/data/alpine": "1.8.3",
+	"influxdb/2.0": "2.0.4",
+	"influxdb/2.0/alpine": "2.0.4",
+}
+
+func lookupVersion(dir string) (*Version, error) {
+	v, ok := manifestVersions[dir]
+	if !ok {
+		return nil, fmt.Errorf("unknown directory: %q", dir)
+	}
+
+	return NewVersion(v)
+}
+
+var expectedOutput = `Maintainers: Test Maintainer
+
+Tags: 1.7, 1.7.10
+Architectures: amd64, arm32v7, arm64v8
+Directory: influxdb/1.7
+
+Tags: 1.7-alpine, 1.7.10-alpine
+Directory: influxdb/1.7/alpine
+
+Tags: 1.7-data, 1.7.10-data
+Directory: influxdb/1.7/data
+
+Tags: 1.7-data-alpine, 1.7.10-data-alpine
+Directory: influxdb/1.7/data/alpine
+
+Tags: 1.7-meta, 1.7.10-meta
+Directory: influxdb/1.7/meta
+
+Tags: 1.7-meta-alpine, 1.7.10-meta-alpine
+Directory: influxdb/1.7/meta/alpine
+
+Tags: 1.8, 1.8.3
+Architectures: amd64, arm32v7, arm64v8
+Directory: influxdb/1.8
+
+Tags: 1.8-alpine, 1.8.3-alpine
+Directory: influxdb/1.8/alpine
+
+Tags: 1.8-data, 1.8.3-data
+Directory: influxdb/1.8/data
+
+Tags: 1.8-data-alpine, 1.8.3-data-alpine
+Directory: influxdb/1.8/data/alpine
+
+Tags: 1.8-meta, 1.8.3-meta
+Directory: influxdb/1.8/meta
+
+Tags: 1.8-meta-alpine, 1.8.3-meta-alpine
+Directory: influxdb/1.8/meta/alpine
+
+Tags: 2.0, 2.0.4, latest
+Architectures: amd64, arm64v8
+Directory: influxdb/2.0
+
+Tags: 2.0-alpine, 2.0.4-alpine, alpine
+Directory: influxdb/2.0/alpine
+`
+
+func TestManifest_e2e(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmp)
+
+	manifestFile := filepath.Join(tmp, "manifest.json")
+	assert.NoError(t, ioutil.WriteFile(manifestFile, []byte(exampleManifest), os.ModePerm))
+
+	manifest, err := ReadImageManifest(manifestFile)
+	assert.NoError(t, err)
+
+	manifest.BaseDir = "influxdb"
+	header := &Header{}
+	for _, maintainer := range manifest.Maintainers {
+		header.Add("Maintainers", maintainer)
+	}
+
+	var buf bytes.Buffer
+	assert.NoError(t, manifest.Write(&buf, header, lookupVersion))
+	assert.Equal(t, expectedOutput, buf.String())
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/influxdata/influxdata-docker
 
 go 1.13
 
-require github.com/spf13/cobra v1.0.0
+require (
+	github.com/spf13/cobra v1.0.0
+	github.com/stretchr/testify v1.5.1
+)

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -56,6 +58,7 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
@@ -80,8 +83,11 @@ github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb6
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
@@ -123,5 +129,6 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/influxdb/manifest.json
+++ b/influxdb/manifest.json
@@ -1,26 +1,24 @@
 {
   "name": "influxdb",
-  "versions": ["1.7", "1.8"],
-  "architectures": [
-    "amd64",
-    "arm32v7",
-    "arm64v8"
+  "maintainers": [
+    "Daniel Moran <dmoran@influxdata.com> (@danxmoran)"
   ],
-  "variants": [
+  "major-versions": [
     {
-      "name": "alpine"
-    },
-    {
-      "name": "data"
-    },
-    {
-      "name": "data/alpine"
-    },
-    {
-      "name": "meta"
-    },
-    {
-      "name": "meta/alpine"
+      "name": "1.x",
+      "versions": ["1.7", "1.8"],
+      "architectures": [
+        "amd64",
+        "arm32v7",
+        "arm64v8"
+      ],
+      "variants": [
+        { "name": "alpine" },
+        { "name": "data" },
+        { "name": "data/alpine" },
+        { "name": "meta" },
+        { "name": "meta/alpine" }
+      ]
     }
   ]
 }

--- a/kapacitor/manifest.json
+++ b/kapacitor/manifest.json
@@ -4,13 +4,18 @@
     "Jonathan A. Sternberg <jonathan@influxdata.com> (@jsternberg)",
     "j. Emrys Landivar <landivar@gmail.com> (@docmerlin)"
   ],
-  "versions": ["1.4", "1.5"],
-  "architectures": [
-    "amd64",
-    "arm32v7",
-    "arm64v8"
-  ],
-  "variants": [
-    {"name": "alpine"}
+  "major-versions": [
+    {
+      "name": "1.x",
+      "versions": ["1.4", "1.5"],
+      "architectures": [
+        "amd64",
+        "arm32v7",
+        "arm64v8"
+      ],
+      "variants": [
+        {"name": "alpine"}
+      ]
+    }
   ]
 }

--- a/telegraf/manifest.json
+++ b/telegraf/manifest.json
@@ -4,19 +4,23 @@
     "David Reimschussel <dreimschussel@influxdata.com> (@reimda)",
     "Steven Soroka <ssoroka@influxdata.com> (@ssoroka)"
   ],
-  "versions": [
-    "1.15",
-    "1.16",
-    "1.17"
-  ],
-  "architectures": [
-    "amd64",
-    "arm32v7",
-    "arm64v8"
-  ],
-  "variants": [
+  "major-versions": [
     {
-      "name": "alpine"
+      "versions": [
+        "1.15",
+        "1.16",
+        "1.17"
+      ],
+      "architectures": [
+        "amd64",
+        "arm32v7",
+        "arm64v8"
+      ],
+      "variants": [
+        {
+          "name": "alpine"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Extracted from #442

InfluxDB 2.0 supports a subset of the architectures and variants currently included in the 1.x line. This felt like the least-impactful way to extend the `dockerlib` tool to support that use-case.

Side note: It looks like the repo's `Jenkinsfile` is set up to run the `dockerlib` tool on merges, but the [job](https://ci.influxdb.com/job/influxdata-docker/) has been disabled for years. I did a test run and saw that both telegraf and kapacitor have mismatches between the `manifest.json` tracked here and the file stored in `influxdata/official-images`. If this is all dead code, I can delete it to avoid future confusion.