### PR TITLE
Bump InfluxDB 1.x to 1.8.4

### DIFF
--- a/influxdb/1.8/Dockerfile
+++ b/influxdb/1.8/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
         gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
     done
 
-ENV INFLUXDB_VERSION 1.8.3
+ENV INFLUXDB_VERSION 1.8.4
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     case "${dpkgArch##*-}" in \
       amd64) ARCH='amd64';; \

--- a/influxdb/1.8/alpine/Dockerfile
+++ b/influxdb/1.8/alpine/Dockerfile
@@ -4,7 +4,7 @@ RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \
     update-ca-certificates
 
-ENV INFLUXDB_VERSION 1.8.3
+ENV INFLUXDB_VERSION 1.8.4
 RUN set -ex && \
     mkdir ~/.gnupg; \
     echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf; \


### PR DESCRIPTION
Purposefully not updating the enterprise `data` and `meta` images since that binary hasn't been fully tested yet.