### PR TITLE
bugfix: increment ping_count on loop

### DIFF
--- a/influxdb/2.0/entrypoint.sh
+++ b/influxdb/2.0/entrypoint.sh
@@ -169,8 +169,9 @@ function wait_for_influxd () {
             log info "got response from influxd, proceeding"
             return
         fi
+        ping_count=$((ping_count+1))
     done
-    log error "failed to detect influxd startup" ping_attempts ${STARTUP_PING_ATTEMPTS}
+    log error "failed to detect influxd startup" ping_attempts ${ping_count}
     exit 1
 }
 


### PR DESCRIPTION
The code previously did not inclement the ping_count variable. This could cause an infinite loop, as the loop conditional depends on this value increasing with each time through. This change adds a statement to increment this value at the end of the loop, and also logs the value of this counter instead of the value it is compared to.