### PR TITLE
Fix ping-until-startup logic for InfluxDB 2.x

### DIFF
--- a/influxdb/2.0/alpine/entrypoint.sh
+++ b/influxdb/2.0/alpine/entrypoint.sh
@@ -245,7 +245,7 @@ function init_influxd () {
 
     # Short-circuit if using upgrade mode and user didn't define any custom scripts,
     # to save startup time from booting & shutting down the server.
-    if [ "${DOCKER_INFLUXDB_INIT_MODE}" = upgrade ] && [ ! user_scripts_present ]; then
+    if [ "${DOCKER_INFLUXDB_INIT_MODE}" = upgrade ] && ! user_scripts_present; then
         trap - EXIT
         return
     fi

--- a/influxdb/2.0/entrypoint.sh
+++ b/influxdb/2.0/entrypoint.sh
@@ -209,6 +209,14 @@ function set_init_resource_ids () {
 # for execution after initial setup/upgrade.
 declare -r USER_SCRIPT_DIR=/docker-entrypoint-initdb.d
 
+# Check if user-defined setup scripts have been mounted into the container.
+function user_scripts_present () {
+    if [ ! -d ${USER_SCRIPT_DIR} ]; then
+        return 1
+    fi
+    test -n "$(find ${USER_SCRIPT_DIR} -name "*.sh" -type f -executable)"
+}
+
 # Execute all shell files mounted into the expected path for user-defined startup scripts.
 function run_user_scripts () {
     if [ -d ${USER_SCRIPT_DIR} ]; then
@@ -238,6 +246,13 @@ function init_influxd () {
     # boltdb file will be generated and cause conflicts.
     if [ "${DOCKER_INFLUXDB_INIT_MODE}" = upgrade ]; then
         upgrade_influxd
+    fi
+
+    # Short-circuit if using upgrade mode and user didn't define any custom scripts,
+    # to save startup time from booting & shutting down the server.
+    if [ "${DOCKER_INFLUXDB_INIT_MODE}" = upgrade ] && ! user_scripts_present; then
+        trap - EXIT
+        return
     fi
 
     # Capture final bind address, and check it is distinct from init addr


### PR DESCRIPTION
Closes #471

1. Instead of `ping`-ing an arbitrary number of times and bailing out, `ping` as long as the PID for `influxd` is still running. This should prevent premature shutdowns of servers that take awhile to boot up for the first time.
2. Don't bother spinning up the "init" instance of `influxd` if there's no logic to run against it. This should shave some time off initial boot-up and prevent the upgrade-timeout-clean loop users have been seeing.

I believe this "fixes" the `rm` issue mentioned in the linked issue by avoiding the code-path entirely. We were previously `rm`-ing files out of the engine directory of the running `influxd` process when startup took too long, and (I think) were seeing the effects of `influxd` concurrently writing files into directories the shell was trying to delete. After this patch, the cleanup logic won't run as long as the `influxd` process is still alive.