### PR TITLE
Detect when --help is passed to influxdb and skip steps that break.

### DIFF
--- a/influxdb/2.0/alpine/entrypoint.sh
+++ b/influxdb/2.0/alpine/entrypoint.sh
@@ -298,6 +298,16 @@ function influxd_main () {
     exec influxd "${@}"
 }
 
+# Check if the --help or -h flag is set in a list of CLI args.
+function check_help_flag () {
+  for arg in "${@}"; do
+      if [ "${arg}" = --help ] || [ "${arg}" = -h ]; then
+          return 0
+      fi
+  done
+  return 1
+}
+
 function main () {
     # Ensure INFLUXD_CONFIG_PATH is set.
     # We do this even if we're not running the main influxd server so subcommands
@@ -320,12 +330,15 @@ function main () {
         shift 1
     fi
 
-    # Configure logging for our wrapper.
-    set_global_log_level "${@}"
-    # Configure data paths used across functions.
-    set_data_paths "${@}"
-    # Ensure volume directories exist w/ correct permissions.
-    create_directories
+
+    if ! check_help_flag "${@}"; then
+        # Configure logging for our wrapper.
+        set_global_log_level "${@}"
+        # Configure data paths used across functions.
+        set_data_paths "${@}"
+        # Ensure volume directories exist w/ correct permissions.
+        create_directories
+    fi
 
     if [ "$(id -u)" = 0 ]; then
         exec gosu influxdb "$BASH_SOURCE" "${@}"

--- a/influxdb/2.0/entrypoint.sh
+++ b/influxdb/2.0/entrypoint.sh
@@ -298,6 +298,16 @@ function influxd_main () {
     exec influxd "${@}"
 }
 
+# Check if the --help or -h flag is set in a list of CLI args.
+function check_help_flag () {
+  for arg in "${@}"; do
+      if [ "${arg}" = --help ] || [ "${arg}" = -h ]; then
+          return 0
+      fi
+  done
+  return 1
+}
+
 function main () {
     # Ensure INFLUXD_CONFIG_PATH is set.
     # We do this even if we're not running the main influxd server so subcommands
@@ -320,12 +330,15 @@ function main () {
         shift 1
     fi
 
-    # Configure logging for our wrapper.
-    set_global_log_level "${@}"
-    # Configure data paths used across functions.
-    set_data_paths "${@}"
-    # Ensure volume directories exist w/ correct permissions.
-    create_directories
+
+    if ! check_help_flag "${@}"; then
+        # Configure logging for our wrapper.
+        set_global_log_level "${@}"
+        # Configure data paths used across functions.
+        set_data_paths "${@}"
+        # Ensure volume directories exist w/ correct permissions.
+        create_directories
+    fi
 
     if [ "$(id -u)" = 0 ]; then
         exec gosu influxdb "$BASH_SOURCE" "${@}"

--- a/influxdb/test/cases/test-help
+++ b/influxdb/test/cases/test-help
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+declare -r SCRIPT_DIR=$(cd $(dirname $0) >/dev/null 2>&1 && pwd)
+source ${SCRIPT_DIR}/common.sh
+
+declare -r tag=$1 container_name=$2 data=$3 config=$4 logs=$5
+
+declare -ra docker_run_influxd=(docker run --rm -i influxdb:${tag})
+
+log_msg Checking various --help commands
+
+# Check that --help works.
+if ! ${docker_run_influxd[@]} --help > "${logs}/help.txt"; then
+    log_msg Error: Failed to run --help
+    exit 1
+fi
+if ! grep -q 'Start up the daemon' "${logs}/help.txt"; then
+    log_msg Error: "${logs}/help.txt" missing expected output
+    exit 1
+fi
+
+# Check that -h works.
+if ! ${docker_run_influxd[@]} -h > "${logs}/h.txt"; then
+    log_msg Error: Failed to run -h
+    exit 1
+fi
+if ! grep -q 'Start up the daemon' "${logs}/h.txt"; then
+    log_msg Error: "${logs}/h.txt" missing expected output
+    exit 1
+fi
+
+# Check that influxd --help works.
+if ! ${docker_run_influxd[@]} influxd --help > "${logs}/influxd-help.txt"; then
+    log_msg Error: Failed to run influxd --help
+    exit 1
+fi
+if ! grep -q 'Start up the daemon' "${logs}/influxd-help.txt"; then
+    log_msg Error: "${logs}/influxd-help.txt" missing expected output
+    exit 1
+fi
+
+# Check that influxd -h works.
+if ! ${docker_run_influxd[@]} influxd -h > "${logs}/influxd-h.txt"; then
+    log_msg Error: Failed to run influxd -h
+    exit 1
+fi
+if ! grep -q 'Start up the daemon' "${logs}/influxd-h.txt"; then
+    log_msg Error: "${logs}/influxd-h.txt" missing expected output
+    exit 1
+fi
+
+# Check that influxd print-config --help works.
+if ! ${docker_run_influxd[@]} influxd print-config --help > "${logs}/influxd-config-help.txt"; then
+    log_msg Error: Failed to run influxd pring-config --help
+    exit 1
+fi
+if ! grep -q 'Print config (in YAML)' "${logs}/influxd-config-help.txt"; then
+    log_msg Error: "${logs}/influxd-config-help.txt" missing expected output
+    exit 1
+fi
+
+# Check that influx --help works.
+if ! ${docker_run_influxd[@]} influx --help > "${logs}/influx-help.txt"; then
+    log_msg Error: Failed to run influx --help
+    exit 1
+fi
+if ! grep -q 'Influx Client' "${logs}/influx-help.txt"; then
+    log_msg Error: "${logs}/influx-help.txt" missing expected output
+    exit 1
+fi


### PR DESCRIPTION
Closes #466 

Some of our setup steps blindly pass all user-specified CLI args to `influxd print-config`. If `--help` or `-h` is in the args, `print-config` doesn't do what we expect, causing downstream failures.

This patch skips the steps that break when `--help` is requested, since they aren't needed to execute `--help`.