### PR TITLE
fix: telegraf do not run as root

### DIFF
--- a/telegraf/1.18/Dockerfile
+++ b/telegraf/1.18/Dockerfile
@@ -30,6 +30,8 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
 
 EXPOSE 8125/udp 8092/udp 8094
 
+USER telegraf
+
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["telegraf"]

--- a/telegraf/1.18/alpine/Dockerfile
+++ b/telegraf/1.18/alpine/Dockerfile
@@ -29,6 +29,10 @@ RUN set -ex && \
 
 EXPOSE 8125/udp 8092/udp 8094
 
+RUN addgroup -S telegraf
+RUN adduser -S telegraf -G telegraf
+USER telegraf
+
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["telegraf"]

--- a/telegraf/1.19/Dockerfile
+++ b/telegraf/1.19/Dockerfile
@@ -30,6 +30,8 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
 
 EXPOSE 8125/udp 8092/udp 8094
 
+USER telegraf
+
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["telegraf"]

--- a/telegraf/1.19/alpine/Dockerfile
+++ b/telegraf/1.19/alpine/Dockerfile
@@ -29,6 +29,10 @@ RUN set -ex && \
 
 EXPOSE 8125/udp 8092/udp 8094
 
+RUN addgroup -S telegraf
+RUN adduser -S telegraf -G telegraf
+USER telegraf
+
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["telegraf"]

--- a/telegraf/1.20/Dockerfile
+++ b/telegraf/1.20/Dockerfile
@@ -30,6 +30,8 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
 
 EXPOSE 8125/udp 8092/udp 8094
 
+USER telegraf
+
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["telegraf"]

--- a/telegraf/1.20/alpine/Dockerfile
+++ b/telegraf/1.20/alpine/Dockerfile
@@ -29,6 +29,10 @@ RUN set -ex && \
 
 EXPOSE 8125/udp 8092/udp 8094
 
+RUN addgroup -S telegraf
+RUN adduser -S telegraf -G telegraf
+USER telegraf
+
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["telegraf"]


### PR DESCRIPTION
This runs Telegraf as a non-root user. For the Debian-based Dockerfiles,
the deb package will create a telegraf user and group for usage. All
that is needed is to say run as the telegraf user.

For Alpine based images, a telegraf user and group needs to be created
and then run as that telegraf user.

Fixes: #412