### PR TITLE
Switch to su to run telegraf as non-root

### DIFF
--- a/telegraf/1.18/Dockerfile
+++ b/telegraf/1.18/Dockerfile
@@ -30,8 +30,6 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
 
 EXPOSE 8125/udp 8092/udp 8094
 
-USER telegraf
-
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["telegraf"]

--- a/telegraf/1.18/alpine/Dockerfile
+++ b/telegraf/1.18/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.14
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata && \
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata su-exec && \
     update-ca-certificates
 
 ENV TELEGRAF_VERSION 1.18.3
@@ -31,8 +31,6 @@ RUN set -ex && \
     chown -R telegraf:telegraf /etc/telegraf
 
 EXPOSE 8125/udp 8092/udp 8094
-
-USER telegraf
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/telegraf/1.18/alpine/entrypoint.sh
+++ b/telegraf/1.18/alpine/entrypoint.sh
@@ -5,4 +5,8 @@ if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi
 
-exec "$@"
+if [ $EUID -ne 0 ]; then
+    exec "$@"
+else
+    exec su-exec telegraf "$@"
+fi

--- a/telegraf/1.18/entrypoint.sh
+++ b/telegraf/1.18/entrypoint.sh
@@ -5,4 +5,8 @@ if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi
 
-exec "$@"
+if [ $EUID -ne 0 ]; then
+    exec "$@"
+else
+    exec setpriv --reuid telegraf --init-groups "$@"
+fi

--- a/telegraf/1.19/Dockerfile
+++ b/telegraf/1.19/Dockerfile
@@ -30,8 +30,6 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
 
 EXPOSE 8125/udp 8092/udp 8094
 
-USER telegraf
-
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["telegraf"]

--- a/telegraf/1.19/alpine/Dockerfile
+++ b/telegraf/1.19/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.14
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata && \
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata su-exec && \
     update-ca-certificates
 
 ENV TELEGRAF_VERSION 1.19.3
@@ -31,8 +31,6 @@ RUN set -ex && \
     chown -R telegraf:telegraf /etc/telegraf
 
 EXPOSE 8125/udp 8092/udp 8094
-
-USER telegraf
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/telegraf/1.19/alpine/entrypoint.sh
+++ b/telegraf/1.19/alpine/entrypoint.sh
@@ -5,4 +5,8 @@ if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi
 
-exec "$@"
+if [ $EUID -ne 0 ]; then
+    exec "$@"
+else
+    exec su-exec telegraf "$@"
+fi

--- a/telegraf/1.19/entrypoint.sh
+++ b/telegraf/1.19/entrypoint.sh
@@ -5,4 +5,8 @@ if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi
 
-exec "$@"
+if [ $EUID -ne 0 ]; then
+    exec "$@"
+else
+    exec setpriv --reuid telegraf --init-groups "$@"
+fi

--- a/telegraf/1.20/Dockerfile
+++ b/telegraf/1.20/Dockerfile
@@ -30,8 +30,6 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
 
 EXPOSE 8125/udp 8092/udp 8094
 
-USER telegraf
-
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["telegraf"]

--- a/telegraf/1.20/alpine/Dockerfile
+++ b/telegraf/1.20/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.14
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata && \
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata su-exec && \
     update-ca-certificates
 
 ENV TELEGRAF_VERSION 1.20.3
@@ -31,8 +31,6 @@ RUN set -ex && \
     chown -R telegraf:telegraf /etc/telegraf
 
 EXPOSE 8125/udp 8092/udp 8094
-
-USER telegraf
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/telegraf/1.20/alpine/entrypoint.sh
+++ b/telegraf/1.20/alpine/entrypoint.sh
@@ -5,7 +5,7 @@ if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi
 
-if [ "$EUID" -ne 0 ]; then
+if [ $EUID -ne 0 ]; then
     exec "$@"
 else
     exec su-exec telegraf "$@"

--- a/telegraf/1.20/alpine/entrypoint.sh
+++ b/telegraf/1.20/alpine/entrypoint.sh
@@ -5,4 +5,8 @@ if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi
 
-exec "$@"
+if [ "$EUID" -ne 0 ]; then
+    exec "$@"
+else
+    exec su-exec telegraf "$@"
+fi

--- a/telegraf/1.20/entrypoint.sh
+++ b/telegraf/1.20/entrypoint.sh
@@ -5,7 +5,7 @@ if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi
 
-if [ "$EUID" -ne 0 ]; then
+if [ $EUID -ne 0 ]; then
     exec "$@"
 else
     exec setpriv --reuid telegraf --init-groups "$@"

--- a/telegraf/1.20/entrypoint.sh
+++ b/telegraf/1.20/entrypoint.sh
@@ -5,4 +5,8 @@ if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi
 
-exec "$@"
+if [ "$EUID" -ne 0 ]; then
+    exec "$@"
+else
+    exec setpriv --reuid telegraf --init-groups "$@"
+fi


### PR DESCRIPTION
I ended up using su-exec on alpine because it's already packaged and easy to use. For debian I used setpriv because it is part of the utils-linux package which is an essential package on debian so it's already installed.