### PR TITLE
fix: delete engine files only but not the path itself

### DIFF
--- a/influxdb/2.0/alpine/entrypoint.sh
+++ b/influxdb/2.0/alpine/entrypoint.sh
@@ -102,7 +102,7 @@ function ensure_init_vars_set () {
 # the DB is already full set up.
 function cleanup_influxd () {
     log warn "cleaning bolt and engine files to prevent conflicts on retry" bolt_path "${BOLT_PATH}" engine_path "${ENGINE_PATH}"
-    rm -rf "${BOLT_PATH}" "${ENGINE_PATH}"
+    rm -rf "${BOLT_PATH}" "${ENGINE_PATH}/"*
 }
 
 # Upgrade V1 data into the V2 format using influxd upgrade.

--- a/influxdb/2.0/entrypoint.sh
+++ b/influxdb/2.0/entrypoint.sh
@@ -102,7 +102,7 @@ function ensure_init_vars_set () {
 # the DB is already full set up.
 function cleanup_influxd () {
     log warn "cleaning bolt and engine files to prevent conflicts on retry" bolt_path "${BOLT_PATH}" engine_path "${ENGINE_PATH}"
-    rm -rf "${BOLT_PATH}" "${ENGINE_PATH}"
+    rm -rf "${BOLT_PATH}" "${ENGINE_PATH}/"*
 }
 
 # Upgrade V1 data into the V2 format using influxd upgrade.

--- a/influxdb/2.1/alpine/entrypoint.sh
+++ b/influxdb/2.1/alpine/entrypoint.sh
@@ -102,7 +102,7 @@ function ensure_init_vars_set () {
 # the DB is already full set up.
 function cleanup_influxd () {
     log warn "cleaning bolt and engine files to prevent conflicts on retry" bolt_path "${BOLT_PATH}" engine_path "${ENGINE_PATH}"
-    rm -rf "${BOLT_PATH}" "${ENGINE_PATH}"
+    rm -rf "${BOLT_PATH}" "${ENGINE_PATH}/"*
 }
 
 # Upgrade V1 data into the V2 format using influxd upgrade.

--- a/influxdb/2.1/entrypoint.sh
+++ b/influxdb/2.1/entrypoint.sh
@@ -102,7 +102,7 @@ function ensure_init_vars_set () {
 # the DB is already full set up.
 function cleanup_influxd () {
     log warn "cleaning bolt and engine files to prevent conflicts on retry" bolt_path "${BOLT_PATH}" engine_path "${ENGINE_PATH}"
-    rm -rf "${BOLT_PATH}" "${ENGINE_PATH}"
+    rm -rf "${BOLT_PATH}" "${ENGINE_PATH}/"*
 }
 
 # Upgrade V1 data into the V2 format using influxd upgrade.


### PR DESCRIPTION
Only bolt and engine files should be deleted on error, because the (engine) path may already exist beforehand and/or docker user may not have permissions to delete it.

Fixes helm charts issue [#350](https://github.com/influxdata/helm-charts/issues/350). In influxdb2 chart, engine path is mount path, permission error is logged and files are not deleted.