### PR TITLE
telegraf: add NET_RAW and NET_BIND_SERVICE capabilities 

### DIFF
--- a/telegraf/1.18/Dockerfile
+++ b/telegraf/1.18/Dockerfile
@@ -26,7 +26,6 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     wget --no-verbose https://dl.influxdata.com/telegraf/releases/telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb && \
     gpg --batch --verify telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb.asc telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb && \
     dpkg -i telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb && \
-    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf && \
     rm -f telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb*
 
 EXPOSE 8125/udp 8092/udp 8094

--- a/telegraf/1.18/Dockerfile
+++ b/telegraf/1.18/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:buster-curl
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors libcap2-bin && \
     rm -rf /var/lib/apt/lists/*
 
 RUN set -ex && \

--- a/telegraf/1.18/alpine/Dockerfile
+++ b/telegraf/1.18/alpine/Dockerfile
@@ -23,7 +23,6 @@ RUN set -ex && \
     mv /usr/src/telegraf*/etc/telegraf/telegraf.conf /etc/telegraf/ && \
     mkdir /etc/telegraf/telegraf.d && \
     cp -a /usr/src/telegraf*/usr/bin/telegraf /usr/bin/ && \
-    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf && \
     gpgconf --kill all && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \
     apk del .build-deps && \

--- a/telegraf/1.18/alpine/Dockerfile
+++ b/telegraf/1.18/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.14
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata su-exec && \
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata su-exec libcap && \
     update-ca-certificates
 
 ENV TELEGRAF_VERSION 1.18.3

--- a/telegraf/1.18/alpine/entrypoint.sh
+++ b/telegraf/1.18/alpine/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# Allow telegraf to send ping packages and bind to privliged ports
+setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+
 if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi

--- a/telegraf/1.18/alpine/entrypoint.sh
+++ b/telegraf/1.18/alpine/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-# Allow telegraf to send ping packages and bind to privliged ports
+# Allow telegraf to send ICMP packets and bind to privliged ports
 setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
 
 if [ "${1:0:1}" = '-' ]; then

--- a/telegraf/1.18/entrypoint.sh
+++ b/telegraf/1.18/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-# Allow telegraf to send ping packages and bind to privliged ports
+# Allow telegraf to send ICMP packets and bind to privliged ports
 setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
 
 if [ "${1:0:1}" = '-' ]; then

--- a/telegraf/1.18/entrypoint.sh
+++ b/telegraf/1.18/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Allow telegraf to send ping packages and bind to privliged ports
+setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+
 if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi

--- a/telegraf/1.19/Dockerfile
+++ b/telegraf/1.19/Dockerfile
@@ -26,7 +26,6 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     wget --no-verbose https://dl.influxdata.com/telegraf/releases/telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb && \
     gpg --batch --verify telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb.asc telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb && \
     dpkg -i telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb && \
-    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf && \
     rm -f telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb*
 
 EXPOSE 8125/udp 8092/udp 8094

--- a/telegraf/1.19/Dockerfile
+++ b/telegraf/1.19/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:buster-curl
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors libcap2-bin && \
     rm -rf /var/lib/apt/lists/*
 
 RUN set -ex && \

--- a/telegraf/1.19/alpine/Dockerfile
+++ b/telegraf/1.19/alpine/Dockerfile
@@ -23,7 +23,6 @@ RUN set -ex && \
     mv /usr/src/telegraf*/etc/telegraf/telegraf.conf /etc/telegraf/ && \
     mkdir /etc/telegraf/telegraf.d && \
     cp -a /usr/src/telegraf*/usr/bin/telegraf /usr/bin/ && \
-    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf && \
     gpgconf --kill all && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \
     apk del .build-deps && \

--- a/telegraf/1.19/alpine/Dockerfile
+++ b/telegraf/1.19/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.14
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata su-exec && \
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata su-exec libcap && \
     update-ca-certificates
 
 ENV TELEGRAF_VERSION 1.19.3

--- a/telegraf/1.19/alpine/entrypoint.sh
+++ b/telegraf/1.19/alpine/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# Allow telegraf to send ping packages and bind to privliged ports
+setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+
 if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi

--- a/telegraf/1.19/alpine/entrypoint.sh
+++ b/telegraf/1.19/alpine/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-# Allow telegraf to send ping packages and bind to privliged ports
+# Allow telegraf to send ICMP packets and bind to privliged ports
 setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
 
 if [ "${1:0:1}" = '-' ]; then

--- a/telegraf/1.19/entrypoint.sh
+++ b/telegraf/1.19/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-# Allow telegraf to send ping packages and bind to privliged ports
+# Allow telegraf to send ICMP packets and bind to privliged ports
 setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
 
 if [ "${1:0:1}" = '-' ]; then

--- a/telegraf/1.19/entrypoint.sh
+++ b/telegraf/1.19/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Allow telegraf to send ping packages and bind to privliged ports
+setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+
 if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi

--- a/telegraf/1.20/Dockerfile
+++ b/telegraf/1.20/Dockerfile
@@ -26,7 +26,6 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     wget --no-verbose https://dl.influxdata.com/telegraf/releases/telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb && \
     gpg --batch --verify telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb.asc telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb && \
     dpkg -i telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb && \
-    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf && \
     rm -f telegraf_${TELEGRAF_VERSION}-1_${ARCH}.deb*
 
 EXPOSE 8125/udp 8092/udp 8094

--- a/telegraf/1.20/Dockerfile
+++ b/telegraf/1.20/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:buster-curl
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors libcap2-bin && \
     rm -rf /var/lib/apt/lists/*
 
 RUN set -ex && \

--- a/telegraf/1.20/alpine/Dockerfile
+++ b/telegraf/1.20/alpine/Dockerfile
@@ -23,7 +23,6 @@ RUN set -ex && \
     mv /usr/src/telegraf*/etc/telegraf/telegraf.conf /etc/telegraf/ && \
     mkdir /etc/telegraf/telegraf.d && \
     cp -a /usr/src/telegraf*/usr/bin/telegraf /usr/bin/ && \
-    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf && \
     gpgconf --kill all && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \
     apk del .build-deps && \

--- a/telegraf/1.20/alpine/Dockerfile
+++ b/telegraf/1.20/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.14
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata su-exec && \
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata su-exec libcap && \
     update-ca-certificates
 
 ENV TELEGRAF_VERSION 1.20.4

--- a/telegraf/1.20/alpine/entrypoint.sh
+++ b/telegraf/1.20/alpine/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# Allow telegraf to send ping packages and bind to privliged ports
+setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+
 if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi

--- a/telegraf/1.20/alpine/entrypoint.sh
+++ b/telegraf/1.20/alpine/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-# Allow telegraf to send ping packages and bind to privliged ports
+# Allow telegraf to send ICMP packets and bind to privliged ports
 setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
 
 if [ "${1:0:1}" = '-' ]; then

--- a/telegraf/1.20/entrypoint.sh
+++ b/telegraf/1.20/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-# Allow telegraf to send ping packages and bind to privliged ports
+# Allow telegraf to send ICMP packets and bind to privliged ports
 setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
 
 if [ "${1:0:1}" = '-' ]; then

--- a/telegraf/1.20/entrypoint.sh
+++ b/telegraf/1.20/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Allow telegraf to send ping packages and bind to privliged ports
+setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+
 if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi

--- a/telegraf/nightly/Dockerfile
+++ b/telegraf/nightly/Dockerfile
@@ -15,7 +15,6 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     esac && \
     wget --no-verbose https://dl.influxdata.com/telegraf/nightlies/telegraf_${TELEGRAF_VERSION}_${ARCH}.deb && \
     dpkg -i telegraf_${TELEGRAF_VERSION}_${ARCH}.deb && \
-    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf && \
     rm -f telegraf_${TELEGRAF_VERSION}_${ARCH}.deb*
 
 EXPOSE 8125/udp 8092/udp 8094

--- a/telegraf/nightly/Dockerfile
+++ b/telegraf/nightly/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:buster-curl
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors libcap2-bin && \
     rm -rf /var/lib/apt/lists/*
 
 ENV TELEGRAF_VERSION nightly

--- a/telegraf/nightly/alpine/Dockerfile
+++ b/telegraf/nightly/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.14
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata su-exec && \
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata su-exec libcap && \
     update-ca-certificates
 
 ENV TELEGRAF_VERSION nightly

--- a/telegraf/nightly/alpine/Dockerfile
+++ b/telegraf/nightly/alpine/Dockerfile
@@ -14,7 +14,6 @@ RUN set -ex && \
     mv /usr/src/telegraf*/etc/telegraf/telegraf.conf /etc/telegraf/ && \
     mkdir /etc/telegraf/telegraf.d && \
     cp -a /usr/src/telegraf*/usr/bin/telegraf /usr/bin/ && \
-    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf && \
     rm -rf *.tar.gz* /usr/src && \
     apk del .build-deps && \
     addgroup -S telegraf && \

--- a/telegraf/nightly/alpine/entrypoint.sh
+++ b/telegraf/nightly/alpine/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# Allow telegraf to send ping packages and bind to privliged ports
+setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+
 if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi

--- a/telegraf/nightly/alpine/entrypoint.sh
+++ b/telegraf/nightly/alpine/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-# Allow telegraf to send ping packages and bind to privliged ports
+# Allow telegraf to send ICMP packets and bind to privliged ports
 setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
 
 if [ "${1:0:1}" = '-' ]; then

--- a/telegraf/nightly/entrypoint.sh
+++ b/telegraf/nightly/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-# Allow telegraf to send ping packages and bind to privliged ports
+# Allow telegraf to send ICMP packets and bind to privliged ports
 setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
 
 if [ "${1:0:1}" = '-' ]; then

--- a/telegraf/nightly/entrypoint.sh
+++ b/telegraf/nightly/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Allow telegraf to send ping packages and bind to privliged ports
+setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+
 if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi


### PR DESCRIPTION
The original fix does not play well with the official docker images build system (see moby/moby#40375, moby/moby#35699, moby/moby#1070). As a result, it was suggested to make these changes to the telegraf binary in the entrypoint script. (see docker-library/official-images#2432

Also adds +x to the nightly entrypoint scripts, which prevent it from getting executed during image launch. Noted this while testing these changes.