### PR TITLE
Telegraf/Alpine/1.20: Support arm64 platform

### DIFF
--- a/telegraf/1.20/alpine/Dockerfile
+++ b/telegraf/1.20/alpine/Dockerfile
@@ -6,7 +6,13 @@ RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors 
 
 ENV TELEGRAF_VERSION 1.20.4
 
-RUN set -ex && \
+RUN ARCH= && \
+    case "$(uname -m)" in \
+        x86_64) ARCH='amd64';; \
+        aarch64) ARCH='arm64';; \
+        *) echo "Unsupported architecture: $(uname -m)"; exit 1;; \
+    esac && \
+    set -ex && \
     mkdir ~/.gnupg; \
     echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf; \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \
@@ -15,11 +21,11 @@ RUN set -ex && \
     do \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done && \
-    wget --no-verbose https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}_static_linux_amd64.tar.gz.asc && \
-    wget --no-verbose https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}_static_linux_amd64.tar.gz && \
-    gpg --batch --verify telegraf-${TELEGRAF_VERSION}_static_linux_amd64.tar.gz.asc telegraf-${TELEGRAF_VERSION}_static_linux_amd64.tar.gz && \
+    wget --no-verbose https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}_linux_${ARCH}.tar.gz.asc && \
+    wget --no-verbose https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}_linux_${ARCH}.tar.gz && \
+    gpg --batch --verify telegraf-${TELEGRAF_VERSION}_linux_${ARCH}.tar.gz.asc telegraf-${TELEGRAF_VERSION}_linux_${ARCH}.tar.gz && \
     mkdir -p /usr/src /etc/telegraf && \
-    tar -C /usr/src -xzf telegraf-${TELEGRAF_VERSION}_static_linux_amd64.tar.gz && \
+    tar -C /usr/src -xzf telegraf-${TELEGRAF_VERSION}_linux_${ARCH}.tar.gz && \
     mv /usr/src/telegraf*/etc/telegraf/telegraf.conf /etc/telegraf/ && \
     mkdir /etc/telegraf/telegraf.d && \
     cp -a /usr/src/telegraf*/usr/bin/telegraf /usr/bin/ && \


### PR DESCRIPTION
This commit adds support for Telegraf 1.20 Alpine arm64 platform by
changing the dockerfile to switch case on the platform architecture

After making this change, we need to change
https://github.com/docker-library/official-images/blob/master/library/telegraf
to add the relevant architectures in 1.20-alpine section

let me know if you want me to port this to `alpine-1.19` and `alpine-1.18`.

Also, I wasn't sure why you're using `static_linux_amd64`, and there's no `static_linux_arm64`, let me know if you want me to change it back for amd64.