### PR TITLE
fix: telegraf setcap command

### DIFF
--- a/telegraf/1.19/alpine/entrypoint.sh
+++ b/telegraf/1.19/alpine/entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 set -e
 
-# Allow telegraf to send ICMP packets and bind to privliged ports
-setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
-
 if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi
@@ -11,5 +8,8 @@ fi
 if [ "$(id -u)" -ne 0 ]; then
     exec "$@"
 else
+    # Allow telegraf to send ICMP packets and bind to privliged ports
+    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+
     exec su-exec telegraf "$@"
 fi

--- a/telegraf/1.19/entrypoint.sh
+++ b/telegraf/1.19/entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-# Allow telegraf to send ICMP packets and bind to privliged ports
-setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
-
 if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi
@@ -11,5 +8,8 @@ fi
 if [ $EUID -ne 0 ]; then
     exec "$@"
 else
+    # Allow telegraf to send ICMP packets and bind to privliged ports
+    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+
     exec setpriv --reuid telegraf --init-groups "$@"
 fi

--- a/telegraf/1.20/alpine/entrypoint.sh
+++ b/telegraf/1.20/alpine/entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 set -e
 
-# Allow telegraf to send ICMP packets and bind to privliged ports
-setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
-
 if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi
@@ -11,5 +8,8 @@ fi
 if [ "$(id -u)" -ne 0 ]; then
     exec "$@"
 else
+    # Allow telegraf to send ICMP packets and bind to privliged ports
+    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+
     exec su-exec telegraf "$@"
 fi

--- a/telegraf/1.20/entrypoint.sh
+++ b/telegraf/1.20/entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-# Allow telegraf to send ICMP packets and bind to privliged ports
-setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
-
 if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi
@@ -11,5 +8,8 @@ fi
 if [ $EUID -ne 0 ]; then
     exec "$@"
 else
+    # Allow telegraf to send ICMP packets and bind to privliged ports
+    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+
     exec setpriv --reuid telegraf --init-groups "$@"
 fi

--- a/telegraf/1.21/alpine/entrypoint.sh
+++ b/telegraf/1.21/alpine/entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 set -e
 
-# Allow telegraf to send ICMP packets and bind to privliged ports
-setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
-
 if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi
@@ -11,5 +8,8 @@ fi
 if [ "$(id -u)" -ne 0 ]; then
     exec "$@"
 else
+    # Allow telegraf to send ICMP packets and bind to privliged ports
+    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+
     exec su-exec telegraf "$@"
 fi

--- a/telegraf/1.21/entrypoint.sh
+++ b/telegraf/1.21/entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-# Allow telegraf to send ICMP packets and bind to privliged ports
-setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
-
 if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi
@@ -11,5 +8,8 @@ fi
 if [ $EUID -ne 0 ]; then
     exec "$@"
 else
+    # Allow telegraf to send ICMP packets and bind to privliged ports
+    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+
     exec setpriv --reuid telegraf --init-groups "$@"
 fi

--- a/telegraf/nightly/alpine/entrypoint.sh
+++ b/telegraf/nightly/alpine/entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 set -e
 
-# Allow telegraf to send ICMP packets and bind to privliged ports
-setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
-
 if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi
@@ -11,5 +8,8 @@ fi
 if [ "$(id -u)" -ne 0 ]; then
     exec "$@"
 else
+    # Allow telegraf to send ICMP packets and bind to privliged ports
+    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+
     exec su-exec telegraf "$@"
 fi

--- a/telegraf/nightly/entrypoint.sh
+++ b/telegraf/nightly/entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-# Allow telegraf to send ICMP packets and bind to privliged ports
-setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
-
 if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi
@@ -11,5 +8,8 @@ fi
 if [ $EUID -ne 0 ]; then
     exec "$@"
 else
+    # Allow telegraf to send ICMP packets and bind to privliged ports
+    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+
     exec setpriv --reuid telegraf --init-groups "$@"
 fi


### PR DESCRIPTION
If a user specifies a different user to launch the telegraf container,
then the setcap command will fail since it needs to be run as root.