### PR TITLE
fix: do not exit on failure of setcap on Telegraf

### DIFF
--- a/telegraf/1.19/alpine/entrypoint.sh
+++ b/telegraf/1.19/alpine/entrypoint.sh
@@ -9,7 +9,7 @@ if [ "$(id -u)" -ne 0 ]; then
     exec "$@"
 else
     # Allow telegraf to send ICMP packets and bind to privliged ports
-    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
 
     exec su-exec telegraf "$@"
 fi

--- a/telegraf/1.19/entrypoint.sh
+++ b/telegraf/1.19/entrypoint.sh
@@ -9,7 +9,7 @@ if [ $EUID -ne 0 ]; then
     exec "$@"
 else
     # Allow telegraf to send ICMP packets and bind to privliged ports
-    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
 
     exec setpriv --reuid telegraf --init-groups "$@"
 fi

--- a/telegraf/1.20/alpine/entrypoint.sh
+++ b/telegraf/1.20/alpine/entrypoint.sh
@@ -9,7 +9,7 @@ if [ "$(id -u)" -ne 0 ]; then
     exec "$@"
 else
     # Allow telegraf to send ICMP packets and bind to privliged ports
-    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
 
     exec su-exec telegraf "$@"
 fi

--- a/telegraf/1.20/entrypoint.sh
+++ b/telegraf/1.20/entrypoint.sh
@@ -9,7 +9,7 @@ if [ $EUID -ne 0 ]; then
     exec "$@"
 else
     # Allow telegraf to send ICMP packets and bind to privliged ports
-    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
 
     exec setpriv --reuid telegraf --init-groups "$@"
 fi

--- a/telegraf/1.21/alpine/entrypoint.sh
+++ b/telegraf/1.21/alpine/entrypoint.sh
@@ -9,7 +9,7 @@ if [ "$(id -u)" -ne 0 ]; then
     exec "$@"
 else
     # Allow telegraf to send ICMP packets and bind to privliged ports
-    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
 
     exec su-exec telegraf "$@"
 fi

--- a/telegraf/1.21/entrypoint.sh
+++ b/telegraf/1.21/entrypoint.sh
@@ -9,7 +9,7 @@ if [ $EUID -ne 0 ]; then
     exec "$@"
 else
     # Allow telegraf to send ICMP packets and bind to privliged ports
-    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
 
     exec setpriv --reuid telegraf --init-groups "$@"
 fi

--- a/telegraf/nightly/alpine/entrypoint.sh
+++ b/telegraf/nightly/alpine/entrypoint.sh
@@ -9,7 +9,7 @@ if [ "$(id -u)" -ne 0 ]; then
     exec "$@"
 else
     # Allow telegraf to send ICMP packets and bind to privliged ports
-    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
 
     exec su-exec telegraf "$@"
 fi

--- a/telegraf/nightly/entrypoint.sh
+++ b/telegraf/nightly/entrypoint.sh
@@ -9,7 +9,7 @@ if [ $EUID -ne 0 ]; then
     exec "$@"
 else
     # Allow telegraf to send ICMP packets and bind to privliged ports
-    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf
+    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
 
     exec setpriv --reuid telegraf --init-groups "$@"
 fi


### PR DESCRIPTION
The Telegraf container entrypoints attempt to use setcap to add
additional capabilites to the telegraf binary. Users who use aufs or run
a kernel that does not allow the setcap option will fail to start the
telegraf container as-is. This allows users to continue to use Telegraf,
but instead print an error message that setcap failed.

Resolves: #561