### PR TITLE
chore: release for plutonium 1.9.6

### DIFF
--- a/influxdb/1.9/data/Dockerfile
+++ b/influxdb/1.9/data/Dockerfile
@@ -9,7 +9,7 @@ RUN set -ex && \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done
 
-ENV INFLUXDB_VERSION 1.9.5-c1.9.5
+ENV INFLUXDB_VERSION 1.9.6-c1.9.6
 RUN wget --no-verbose https://dl.influxdata.com/enterprise/releases/influxdb-data_${INFLUXDB_VERSION}_amd64.deb.asc && \
     wget --no-verbose https://dl.influxdata.com/enterprise/releases/influxdb-data_${INFLUXDB_VERSION}_amd64.deb && \
     gpg --batch --verify influxdb-data_${INFLUXDB_VERSION}_amd64.deb.asc influxdb-data_${INFLUXDB_VERSION}_amd64.deb && \

--- a/influxdb/1.9/data/alpine/Dockerfile
+++ b/influxdb/1.9/data/alpine/Dockerfile
@@ -4,7 +4,7 @@ RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \
     update-ca-certificates
 
-ENV INFLUXDB_VERSION 1.9.5-c1.9.5
+ENV INFLUXDB_VERSION 1.9.6-c1.9.6
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \
     for key in \

--- a/influxdb/1.9/meta/Dockerfile
+++ b/influxdb/1.9/meta/Dockerfile
@@ -9,7 +9,7 @@ RUN set -ex && \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done
 
-ENV INFLUXDB_VERSION 1.9.5-c1.9.5
+ENV INFLUXDB_VERSION 1.9.6-c1.9.6
 RUN wget --no-verbose https://dl.influxdata.com/enterprise/releases/influxdb-meta_${INFLUXDB_VERSION}_amd64.deb.asc && \
     wget --no-verbose https://dl.influxdata.com/enterprise/releases/influxdb-meta_${INFLUXDB_VERSION}_amd64.deb && \
     gpg --batch --verify influxdb-meta_${INFLUXDB_VERSION}_amd64.deb.asc influxdb-meta_${INFLUXDB_VERSION}_amd64.deb && \

--- a/influxdb/1.9/meta/alpine/Dockerfile
+++ b/influxdb/1.9/meta/alpine/Dockerfile
@@ -4,7 +4,7 @@ RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \
     update-ca-certificates
 
-ENV INFLUXDB_VERSION 1.9.5-c1.9.5
+ENV INFLUXDB_VERSION 1.9.6-c1.9.6
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \
     for key in \


### PR DESCRIPTION
Does not contain OSS docker images.