### PR TITLE
chore(ci): update image for VM based jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
 
   test-influxdb:
     machine:
-      image: ubuntu-2004:202111-01
+      image: ubuntu-2004:202111-02
     parameters:
       version:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
 
   test-influxdb:
     machine:
-      image: ubuntu-2004:202111-02
+      image: ubuntu-2004:202111-01
     parameters:
       version:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,8 @@ jobs:
       - run: bash circle-test.sh
 
   test-influxdb:
-    machine: true
+    machine:
+      image: ubuntu-2004:202111-01
     parameters:
       version:
         type: string


### PR DESCRIPTION
Update to avoid potential CI issues mentioned in deprecated message in CircleCI.