### PR TITLE
Fix 'influxd not found' error in InfluxDB 1.9.x images

### DIFF
--- a/influxdb/1.9/data/alpine/Dockerfile
+++ b/influxdb/1.9/data/alpine/Dockerfile
@@ -17,9 +17,9 @@ RUN set -ex && \
     gpg --batch --verify influxdb-data-${INFLUXDB_VERSION}_linux_amd64.tar.gz.asc influxdb-data-${INFLUXDB_VERSION}_linux_amd64.tar.gz && \
     mkdir -p /usr/src && \
     tar -C /usr/src -xzf influxdb-data-${INFLUXDB_VERSION}_linux_amd64.tar.gz && \
-    rm -f /usr/src/influxdb-*/influxdb.conf && \
-    chmod +x /usr/src/influxdb-*/* && \
-    cp -a /usr/src/influxdb-*/* /usr/bin/ && \
+    rm -f /usr/src/influxdb-*/etc/influxdb/influxdb.conf && \
+    chmod +x /usr/src/influxdb-*/usr/bin/* && \
+    cp -a /usr/src/influxdb-*/usr/bin/* /usr/bin/ && \
     gpgconf --kill all && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \
     apk del .build-deps

--- a/influxdb/1.9/meta/alpine/Dockerfile
+++ b/influxdb/1.9/meta/alpine/Dockerfile
@@ -17,9 +17,9 @@ RUN set -ex && \
     gpg --batch --verify influxdb-meta-${INFLUXDB_VERSION}_linux_amd64.tar.gz.asc influxdb-meta-${INFLUXDB_VERSION}_linux_amd64.tar.gz && \
     mkdir -p /usr/src && \
     tar -C /usr/src -xzf influxdb-meta-${INFLUXDB_VERSION}_linux_amd64.tar.gz && \
-    rm -f /usr/src/influxdb-*/influxdb-meta.conf && \
-    chmod +x /usr/src/influxdb-*/* && \
-    cp -a /usr/src/influxdb-*/* /usr/bin/ && \
+    rm -f /usr/src/influxdb-*/etc/influxdb/influxdb-meta.conf && \
+    chmod +x /usr/src/influxdb-*/usr/bin/* && \
+    cp -a /usr/src/influxdb-*/usr/bin/* /usr/bin/ && \
     gpgconf --kill all && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \
     apk del .build-deps


### PR DESCRIPTION
Changes:

1. Fix InfluxDB files path

Resolves: #613