### PR TITLE
chore: upgrade all images from "stretch" to "bullseye".

### DIFF
--- a/chronograf/1.6/Dockerfile
+++ b/chronograf/1.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 
 RUN set -ex && \
     mkdir ~/.gnupg; \

--- a/chronograf/1.7/Dockerfile
+++ b/chronograf/1.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 
 RUN set -ex && \
     mkdir ~/.gnupg; \

--- a/chronograf/1.8/Dockerfile
+++ b/chronograf/1.8/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 
 RUN set -ex && \
     mkdir ~/.gnupg; \

--- a/chronograf/1.9/Dockerfile
+++ b/chronograf/1.9/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 
 RUN set -ex && \
     mkdir ~/.gnupg; \


### PR DESCRIPTION
*Mostly Closes https://github.com/influxdata/influxdata-docker/issues/367

Images that are no longer specified in `official-images` need to be rebuilt manually for this change to take effect.