### PR TITLE
chore: revert changes to GPG

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,21 @@ workflows:
   version: 2
   ci:
     jobs:
-      - build
+      - build:
+          name: build-chronograf
+          product: chronograf
+      - build:
+          name: build-dockerlib
+          product: dockerlib
+      - build:
+          name: build-influxdb
+          product: influxdb
+      - build:
+          name: build-kapacitor
+          product: kapacitor
+      - build:
+          name: build-telegraf
+          product: telegraf
       - test-influxdb:
           matrix:
             parameters:
@@ -36,12 +50,16 @@ workflows:
 
 jobs:
   build:
+    parameters:
+      product:
+        type: string
     docker:
       - image: cimg/go:1.15.6
     steps:
       - checkout
       - setup_remote_docker
-      - run: bash circle-test.sh
+      - run: |
+          ./circle-test.sh "<< parameters.product >>"
 
   test-influxdb:
     <<: *ubuntu_machine

--- a/influxdb/2.0/Dockerfile
+++ b/influxdb/2.0/Dockerfile
@@ -5,12 +5,6 @@ RUN groupadd -r influxdb --gid=1000 && \
     mkdir -p /home/influxdb && \
     chown -R influxdb:influxdb /home/influxdb
 
-# Configure GNUPG
-RUN mkdir -p /root/.gnupg && chmod 700 /root/.gnupg                                               && \
-    echo "disable-ipv6" >> /root/.gnupg/dirmngr.conf                                              && \
-    gpg --batch --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
-    gpg --batch --keyserver keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-
 # Install gosu for easy step-down from root.
 # https://github.com/tianon/gosu/releases
 ENV GOSU_VER 1.12
@@ -18,7 +12,11 @@ RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)" && \
     wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VER/gosu-$dpkgArch" && \
     wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VER/gosu-$dpkgArch.asc" && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
     gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc && \
     chmod +x /usr/local/bin/gosu && \
     gosu --version && \
     gosu nobody true
@@ -33,19 +31,16 @@ RUN set -eux && \
     esac && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz.asc && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf && \
+    gpg --batch --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
     gpg --batch --verify influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz.asc influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
+    gpgconf --kill all && \
     tar xzf influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
     cp influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}/influx* /usr/local/bin/ && \
+    rm -rf "$GNUPGHOME" influxdb2.key influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}* && \
     influxd version && \
     influx version
-
-# Remove GNUPG Configuration
-RUN gpgconf --kill all                                      && \
-    rm -rf                                                     \
-      "/root/.gnupg"                                           \
-      influxdb2.key                                            \
-      influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}*             \
-      influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}*
 
 # Create standard directories expected by the entry-point.
 RUN mkdir /docker-entrypoint-initdb.d && \

--- a/influxdb/2.0/alpine/Dockerfile
+++ b/influxdb/2.0/alpine/Dockerfile
@@ -9,11 +9,6 @@ RUN addgroup -S -g 1000 influxdb && \
     mkdir -p /home/influxdb && \
     chown -R influxdb:influxdb /home/influxdb
 
-# Configure GNUPG
-RUN mkdir -p /root/.gnupg && chmod 700 /root/.gnupg                                               && \
-    echo "disable-ipv6" >> /root/.gnupg/dirmngr.conf                                              && \
-    gpg --batch --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A
-
 ENV INFLUXDB_VERSION 2.0.9
 RUN set -eux && \
     ARCH="$(apk --print-arch)" && \
@@ -26,19 +21,16 @@ RUN set -eux && \
     fi && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz.asc && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf && \
+    gpg --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
     gpg --batch --verify influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz.asc influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
+    gpgconf --kill all && \
     tar xzf influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
     cp influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}/influx* /usr/local/bin/ && \
+    rm -rf "$GNUPGHOME" influxdb2.key influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}* && \
     influxd version && \
     influx version
-
-# Remove GNUPG Configuration
-RUN gpgconf --kill all                                      && \
-    rm -rf                                                     \
-      "/root/.gnupg"                                           \
-      influxdb2.key                                            \
-      influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}*             \
-      influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}*
 
 # Create standard directories expected by the entry-point.
 RUN mkdir /docker-entrypoint-initdb.d && \

--- a/influxdb/2.1/Dockerfile
+++ b/influxdb/2.1/Dockerfile
@@ -5,12 +5,6 @@ RUN groupadd -r influxdb --gid=1000 && \
     mkdir -p /home/influxdb && \
     chown -R influxdb:influxdb /home/influxdb
 
-# Configure GNUPG
-RUN mkdir -p /root/.gnupg && chmod 700 /root/.gnupg                                               && \
-    echo "disable-ipv6" >> /root/.gnupg/dirmngr.conf                                              && \
-    gpg --batch --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
-    gpg --batch --keyserver keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-
 # Install gosu for easy step-down from root.
 # https://github.com/tianon/gosu/releases
 ENV GOSU_VER 1.12
@@ -18,7 +12,11 @@ RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)" && \
     wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VER/gosu-$dpkgArch" && \
     wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VER/gosu-$dpkgArch.asc" && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
     gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc && \
     chmod +x /usr/local/bin/gosu && \
     gosu --version && \
     gosu nobody true
@@ -34,9 +32,14 @@ RUN set -eux && \
     esac && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz.asc && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf && \
+    gpg --batch --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
     gpg --batch --verify influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz.asc influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
     cp influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}/influxd /usr/local/bin/influxd && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" influxdb2.key influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}* && \
     influxd version
 
 # Install the influx CLI
@@ -50,18 +53,15 @@ RUN set -eux && \
     esac && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz.asc && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf && \
+    gpg --batch --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
     gpg --batch --verify influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz.asc influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
     cp influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}/influx /usr/local/bin/influx && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" influxdb2.key influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}* && \
     influx version
-
-# Remove GNUPG Configuration
-RUN gpgconf --kill all                                      && \
-    rm -rf                                                     \
-      "/root/.gnupg"                                           \
-      influxdb2.key                                            \
-      influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}*             \
-      influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}*
 
 # Create standard directories expected by the entry-point.
 RUN mkdir /docker-entrypoint-initdb.d && \

--- a/influxdb/2.1/alpine/Dockerfile
+++ b/influxdb/2.1/alpine/Dockerfile
@@ -9,12 +9,7 @@ RUN addgroup -S -g 1000 influxdb && \
     mkdir -p /home/influxdb && \
     chown -R influxdb:influxdb /home/influxdb
 
-# Configure GNUPG
-RUN mkdir -p /root/.gnupg && chmod 700 /root/.gnupg                                               && \
-    echo "disable-ipv6" >> /root/.gnupg/dirmngr.conf                                              && \
-    gpg --batch --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A
-
-# Install the influxd server
+# Install the infuxd server
 ENV INFLUXDB_VERSION 2.1.1
 RUN set -eux && \
     ARCH="$(apk --print-arch)" && \
@@ -27,9 +22,14 @@ RUN set -eux && \
     fi && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz.asc && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf && \
+    gpg --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
     gpg --batch --verify influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz.asc influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
     cp influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}/influxd /usr/local/bin/influxd && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" influxdb2.key influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}* && \
     influxd version
 
 # Install the influx CLI
@@ -45,18 +45,15 @@ RUN set -eux && \
     fi && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz.asc && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf && \
+    gpg --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
     gpg --batch --verify influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz.asc influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
     cp influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}/influx /usr/local/bin/influx && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" influxdb2.key influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}* && \
     influx version
-
-# Remove GNUPG Configuration
-RUN gpgconf --kill all                                      && \
-    rm -rf                                                     \
-      "/root/.gnupg"                                           \
-      influxdb2.key                                            \
-      influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}*             \
-      influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}*
 
 # Create standard directories expected by the entry-point.
 RUN mkdir /docker-entrypoint-initdb.d && \

--- a/influxdb/2.2/Dockerfile
+++ b/influxdb/2.2/Dockerfile
@@ -5,12 +5,6 @@ RUN groupadd -r influxdb --gid=1000 && \
     mkdir -p /home/influxdb && \
     chown -R influxdb:influxdb /home/influxdb
 
-# Configure GNUPG
-RUN mkdir -p /root/.gnupg && chmod 700 /root/.gnupg                                               && \
-    echo "disable-ipv6" >> /root/.gnupg/dirmngr.conf                                              && \
-    gpg --batch --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
-    gpg --batch --keyserver keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-
 # Install gosu for easy step-down from root.
 # https://github.com/tianon/gosu/releases
 ENV GOSU_VER 1.12
@@ -18,7 +12,11 @@ RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)" && \
     wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VER/gosu-$dpkgArch" && \
     wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VER/gosu-$dpkgArch.asc" && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
     gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc && \
     chmod +x /usr/local/bin/gosu && \
     gosu --version && \
     gosu nobody true
@@ -34,9 +32,14 @@ RUN set -eux && \
     esac && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz.asc && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf && \
+    gpg --batch --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
     gpg --batch --verify influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz.asc influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
     cp influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}/influxd /usr/local/bin/influxd && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" influxdb2.key influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}* && \
     influxd version
 
 # Install the influx CLI
@@ -50,18 +53,15 @@ RUN set -eux && \
     esac && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz.asc && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf && \
+    gpg --batch --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
     gpg --batch --verify influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz.asc influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
     cp influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}/influx /usr/local/bin/influx && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" influxdb2.key influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}* && \
     influx version
-
-# Remove GNUPG Configuration
-RUN gpgconf --kill all                                      && \
-    rm -rf                                                     \
-      "/root/.gnupg"                                           \
-      influxdb2.key                                            \
-      influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}*             \
-      influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}*
 
 # Create standard directories expected by the entry-point.
 RUN mkdir /docker-entrypoint-initdb.d && \

--- a/influxdb/2.2/alpine/Dockerfile
+++ b/influxdb/2.2/alpine/Dockerfile
@@ -9,11 +9,6 @@ RUN addgroup -S -g 1000 influxdb && \
     mkdir -p /home/influxdb && \
     chown -R influxdb:influxdb /home/influxdb
 
-# Configure GNUPG
-RUN mkdir -p /root/.gnupg && chmod 700 /root/.gnupg                                               && \
-    echo "disable-ipv6" >> /root/.gnupg/dirmngr.conf                                              && \
-    gpg --batch --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A
-
 # Install the infuxd server
 ENV INFLUXDB_VERSION 2.2.0
 RUN set -eux && \
@@ -27,9 +22,14 @@ RUN set -eux && \
     fi && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz.asc && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf && \
+    gpg --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
     gpg --batch --verify influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz.asc influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
     cp influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}/influxd /usr/local/bin/influxd && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" influxdb2.key influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}* && \
     influxd version
 
 # Install the influx CLI
@@ -45,18 +45,15 @@ RUN set -eux && \
     fi && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz.asc && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf && \
+    gpg --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
     gpg --batch --verify influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz.asc influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
     cp influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}/influx /usr/local/bin/influx && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" influxdb2.key influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}* && \
     influx version
-
-# Remove GNUPG Configuration
-RUN gpgconf --kill all                                      && \
-    rm -rf                                                     \
-      "/root/.gnupg"                                           \
-      influxdb2.key                                            \
-      influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}*             \
-      influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}*
 
 # Create standard directories expected by the entry-point.
 RUN mkdir /docker-entrypoint-initdb.d && \

--- a/influxdb/2.3/Dockerfile
+++ b/influxdb/2.3/Dockerfile
@@ -5,12 +5,6 @@ RUN groupadd -r influxdb --gid=1000 && \
     mkdir -p /home/influxdb && \
     chown -R influxdb:influxdb /home/influxdb
 
-# Configure GNUPG
-RUN mkdir -p /root/.gnupg && chmod 700 /root/.gnupg                                               && \
-    echo "disable-ipv6" >> /root/.gnupg/dirmngr.conf                                              && \
-    gpg --batch --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
-    gpg --batch --keyserver keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-
 # Install gosu for easy step-down from root.
 # https://github.com/tianon/gosu/releases
 ENV GOSU_VER 1.12
@@ -18,7 +12,11 @@ RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)" && \
     wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VER/gosu-$dpkgArch" && \
     wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VER/gosu-$dpkgArch.asc" && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
     gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc && \
     chmod +x /usr/local/bin/gosu && \
     gosu --version && \
     gosu nobody true
@@ -34,9 +32,14 @@ RUN set -eux && \
     esac && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz.asc && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf && \
+    gpg --batch --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
     gpg --batch --verify influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz.asc influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
     cp influxdb2_linux_${ARCH}/influxd /usr/local/bin/influxd && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" influxdb2.key influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}* && \
     influxd version
 
 # Install the influx CLI
@@ -50,18 +53,15 @@ RUN set -eux && \
     esac && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz.asc && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf && \
+    gpg --batch --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
     gpg --batch --verify influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz.asc influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
     cp influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}/influx /usr/local/bin/influx && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" influxdb2.key influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}* && \
     influx version
-
-# Remove GNUPG Configuration
-RUN gpgconf --kill all                                      && \
-    rm -rf                                                     \
-      "/root/.gnupg"                                           \
-      influxdb2.key                                            \
-      influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}*             \
-      influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}*
 
 # Create standard directories expected by the entry-point.
 RUN mkdir /docker-entrypoint-initdb.d && \

--- a/influxdb/2.3/alpine/Dockerfile
+++ b/influxdb/2.3/alpine/Dockerfile
@@ -9,11 +9,6 @@ RUN addgroup -S -g 1000 influxdb && \
     mkdir -p /home/influxdb && \
     chown -R influxdb:influxdb /home/influxdb
 
-# Configure GNUPG
-RUN mkdir -p /root/.gnupg && chmod 700 /root/.gnupg                                               && \
-    echo "disable-ipv6" >> /root/.gnupg/dirmngr.conf                                              && \
-    gpg --batch --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A
-
 # Install the infuxd server
 ENV INFLUXDB_VERSION 2.3.0
 RUN set -eux && \
@@ -27,9 +22,14 @@ RUN set -eux && \
     fi && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz.asc && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf && \
+    gpg --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
     gpg --batch --verify influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz.asc influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
     cp influxdb2_linux_${ARCH}/influxd /usr/local/bin/influxd && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" influxdb2.key influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}* && \
     influxd version
 
 # Install the influx CLI
@@ -45,18 +45,15 @@ RUN set -eux && \
     fi && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz.asc && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf && \
+    gpg --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
     gpg --batch --verify influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz.asc influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
     cp influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}/influx /usr/local/bin/influx && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" influxdb2.key influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}* && \
     influx version
-
-# Remove GNUPG Configuration
-RUN gpgconf --kill all                                      && \
-    rm -rf                                                     \
-      "/root/.gnupg"                                           \
-      influxdb2.key                                            \
-      influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}*             \
-      influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}*
 
 # Create standard directories expected by the entry-point.
 RUN mkdir /docker-entrypoint-initdb.d && \

--- a/influxdb/2.4/Dockerfile
+++ b/influxdb/2.4/Dockerfile
@@ -5,12 +5,6 @@ RUN groupadd -r influxdb --gid=1000 && \
     mkdir -p /home/influxdb && \
     chown -R influxdb:influxdb /home/influxdb
 
-# Configure GNUPG
-RUN mkdir -p /root/.gnupg && chmod 700 /root/.gnupg                                               && \
-    echo "disable-ipv6" >> /root/.gnupg/dirmngr.conf                                              && \
-    gpg --batch --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
-    gpg --batch --keyserver keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-
 # Install gosu for easy step-down from root.
 # https://github.com/tianon/gosu/releases
 ENV GOSU_VER 1.12
@@ -18,7 +12,11 @@ RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)" && \
     wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VER/gosu-$dpkgArch" && \
     wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VER/gosu-$dpkgArch.asc" && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
     gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc && \
     chmod +x /usr/local/bin/gosu && \
     gosu --version && \
     gosu nobody true
@@ -34,9 +32,14 @@ RUN set -eux && \
     esac && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz.asc && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf && \
+    gpg --batch --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
     gpg --batch --verify influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz.asc influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
     cp influxdb2_linux_${ARCH}/influxd /usr/local/bin/influxd && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" influxdb2.key influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}* && \
     influxd version
 
 # Install the influx CLI
@@ -50,18 +53,15 @@ RUN set -eux && \
     esac && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz.asc && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf && \
+    gpg --batch --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
     gpg --batch --verify influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz.asc influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
     cp influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}/influx /usr/local/bin/influx && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" influxdb2.key influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}* && \
     influx version
-
-# Remove GNUPG Configuration
-RUN gpgconf --kill all                                      && \
-    rm -rf                                                     \
-      "/root/.gnupg"                                           \
-      influxdb2.key                                            \
-      influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}*             \
-      influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}*
 
 # Create standard directories expected by the entry-point.
 RUN mkdir /docker-entrypoint-initdb.d && \

--- a/influxdb/2.4/alpine/Dockerfile
+++ b/influxdb/2.4/alpine/Dockerfile
@@ -9,11 +9,6 @@ RUN addgroup -S -g 1000 influxdb && \
     mkdir -p /home/influxdb && \
     chown -R influxdb:influxdb /home/influxdb
 
-# Configure GNUPG
-RUN mkdir -p /root/.gnupg && chmod 700 /root/.gnupg                                               && \
-    echo "disable-ipv6" >> /root/.gnupg/dirmngr.conf                                              && \
-    gpg --batch --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A
-
 # Install the infuxd server
 ENV INFLUXDB_VERSION 2.4.0
 RUN set -eux && \
@@ -27,9 +22,14 @@ RUN set -eux && \
     fi && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz.asc && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf && \
+    gpg --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
     gpg --batch --verify influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz.asc influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}.tar.gz && \
     cp influxdb2_linux_${ARCH}/influxd /usr/local/bin/influxd && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" influxdb2.key influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}* && \
     influxd version
 
 # Install the influx CLI
@@ -45,18 +45,15 @@ RUN set -eux && \
     fi && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz.asc && \
     wget --no-verbose https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf && \
+    gpg --keyserver keys.openpgp.org --recv-keys 8C2D403D3C3BDB81A4C27C883C3E4B7317FFE40A && \
     gpg --batch --verify influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz.asc influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}.tar.gz && \
     cp influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}/influx /usr/local/bin/influx && \
+    gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" influxdb2.key influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}* && \
     influx version
-
-# Remove GNUPG Configuration
-RUN gpgconf --kill all                                      && \
-    rm -rf                                                     \
-      "/root/.gnupg"                                           \
-      influxdb2.key                                            \
-      influxdb2-${INFLUXDB_VERSION}-linux-${ARCH}*             \
-      influxdb2-client-${INFLUX_CLI_VERSION}-linux-${ARCH}*
 
 # Create standard directories expected by the entry-point.
 RUN mkdir /docker-entrypoint-initdb.d && \


### PR DESCRIPTION
This reverts the changes made to GPG in https://github.com/influxdata/influxdata-docker/pull/632 and separates the `build` CircleCI job into several independent jobs. I suspect that CircleCI was experiencing networking issues while we were trying to cut the previous release. This caused problems with both `apt` and `gpg`. The reverted commit removed many of the `gpg --keyserver XXX --recv-keys` calls which increased the likelihood of success.

It seems that the CircleCI networking issues have been resolved.