### PR TITLE
chore(kapacitor): 1.6.5

### DIFF
--- a/kapacitor/1.6/Dockerfile
+++ b/kapacitor/1.6/Dockerfile
@@ -14,7 +14,7 @@ RUN set -ex && \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done
 
-ENV KAPACITOR_VERSION 1.6.4
+ENV KAPACITOR_VERSION 1.6.5
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     case "${dpkgArch##*-}" in \
       amd64) ARCH='amd64';; \

--- a/kapacitor/1.6/alpine/Dockerfile
+++ b/kapacitor/1.6/alpine/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:3.14
+FROM alpine:3.16
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \
     update-ca-certificates
 
-ENV KAPACITOR_VERSION 1.6.4
+ENV KAPACITOR_VERSION 1.6.5
 
 RUN set -ex && \
     mkdir ~/.gnupg; \


### PR DESCRIPTION
Update to kappa 1.6.5, also bumps kappa's alpine version to 3.16