### PR TITLE
chore(kapacitor): 1.6.5

### DIFF
--- a/circle-test.sh
+++ b/circle-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 dir=.
 if [ $# -gt 0 ]; then
@@ -20,7 +20,7 @@ docker_build() {
     docker build --no-cache --rm=false "$@"
   else
     # Local building should use the cache for speedy development.
-    docker build --rm=true "$@"
+    docker build --no-cache --rm=true "$@"
   fi
 }
 

--- a/kapacitor/1.6/Dockerfile
+++ b/kapacitor/1.6/Dockerfile
@@ -1,31 +1,30 @@
-FROM buildpack-deps:stretch-curl
+FROM buildpack-deps:jammy-curl
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y bash-completion && \
     awk 'f{if(sub(/^#/,"",$0)==0){f=0}};/^# enable bash completion/{f=1};{print;}' /etc/bash.bashrc > /etc/bash.bashrc.new && \
     mv /etc/bash.bashrc.new /etc/bash.bashrc
 
-RUN set -ex && \
-    mkdir ~/.gnupg; \
-    echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf; \
-    for key in \
-        05CE15085FC09D18E99EFB22684A14CF2582E0C5 ; \
-    do \
-        gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
-    done
-
 ENV KAPACITOR_VERSION 1.6.5
-RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
+
+RUN set -eux && \
+    ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     case "${dpkgArch##*-}" in \
-      amd64) ARCH='amd64';; \
-      arm64) ARCH='arm64';; \
-      *)     echo "Unsupported architecture: ${dpkgArch}"; exit 1;; \
+        amd64) ARCH='amd64';; \
+        arm64) ARCH='arm64';; \
+        *)     echo "Unsupported architecture: ${dpkgArch}"; exit 1;; \
     esac && \
     wget --no-verbose https://dl.influxdata.com/kapacitor/releases/kapacitor_${KAPACITOR_VERSION}-1_${ARCH}.deb.asc && \
     wget --no-verbose https://dl.influxdata.com/kapacitor/releases/kapacitor_${KAPACITOR_VERSION}-1_${ARCH}.deb && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf && \
+    gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys 05CE15085FC09D18E99EFB22684A14CF2582E0C5 && \
     gpg --batch --verify kapacitor_${KAPACITOR_VERSION}-1_${ARCH}.deb.asc kapacitor_${KAPACITOR_VERSION}-1_${ARCH}.deb && \
+    rm -rf "$GNUPGHOME" && \
     dpkg -i kapacitor_${KAPACITOR_VERSION}-1_${ARCH}.deb && \
+    gpgconf --kill all && \
     rm -f kapacitor_${KAPACITOR_VERSION}-1_${ARCH}.deb*
+
 COPY kapacitor.conf /etc/kapacitor/kapacitor.conf
 
 EXPOSE 9092


### PR DESCRIPTION
Update kappa to 1.6.5
This also updates the build dependencies.  The build was failing on docker hub because stretch is no longer supported.