### PR TITLE
chore: update telegraf alpine images to 3.16

### DIFF
--- a/telegraf/1.22/alpine/Dockerfile
+++ b/telegraf/1.22/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata su-exec libcap && \

--- a/telegraf/1.23/alpine/Dockerfile
+++ b/telegraf/1.23/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata su-exec libcap && \

--- a/telegraf/nightly/alpine/Dockerfile
+++ b/telegraf/nightly/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata su-exec libcap && \


### PR DESCRIPTION
In prep for Telegraf v1.24 in September, this updated the Alpine images for the supported images to 3.16. Telegraf v1.21 is not updated since it will be dropped as a part of the v1.24 release.