### PR TITLE
telegraf: use normal amd64 binary

### DIFF
--- a/telegraf/nightly/alpine/Dockerfile
+++ b/telegraf/nightly/alpine/Dockerfile
@@ -8,9 +8,9 @@ ENV TELEGRAF_VERSION nightly
 
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps wget tar && \
-    wget --no-verbose https://dl.influxdata.com/telegraf/nightlies/telegraf-${TELEGRAF_VERSION}_static_linux_amd64.tar.gz && \
+    wget --no-verbose https://dl.influxdata.com/telegraf/nightlies/telegraf-${TELEGRAF_VERSION}_linux_amd64.tar.gz && \
     mkdir -p /usr/src /etc/telegraf && \
-    tar -C /usr/src -xzf telegraf-${TELEGRAF_VERSION}_static_linux_amd64.tar.gz && \
+    tar -C /usr/src -xzf telegraf-${TELEGRAF_VERSION}_linux_amd64.tar.gz && \
     mv /usr/src/telegraf*/etc/telegraf/telegraf.conf /etc/telegraf/ && \
     mkdir /etc/telegraf/telegraf.d && \
     cp -a /usr/src/telegraf*/usr/bin/telegraf /usr/bin/ && \


### PR DESCRIPTION
We no longer produce a static specific package. All linux binaries are static on nightly images. v1.26.0 will be the first release with this as well.