### PR TITLE
fix: correct toml parsing during initialization

### DIFF
--- a/influxdb/2.2/Dockerfile
+++ b/influxdb/2.2/Dockerfile
@@ -11,19 +11,19 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install yq for configuration parsing
+# Install dasel for configuration parsing
 RUN case "$(dpkg --print-architecture)" in \
       *amd64) arch=amd64 ;; \
       *arm64) arch=arm64 ;; \
       *) echo 'Unsupported architecture' && exit 1 ;; \
     esac && \
-    curl -fLo /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v4.30.8/yq_linux_${arch}" && \
+    curl -fLo /usr/local/bin/dasel "https://github.com/TomWright/dasel/releases/download/v2.1.2/dasel_linux_${arch}" && \
     case ${arch} in \
-      amd64) echo '6c911103e0dcc54e2ba07e767d2d62bcfc77452b39ebaee45b1c46f062f4fd26 /usr/local/bin/yq' ;; \
-      arm64) echo '95092e8b5332890c46689679b5e4360d96873c025ad8bafd961688f28ea434c7 /usr/local/bin/yq' ;; \
+      amd64) echo 'e4b43d8c7d76904e2401dc81de0900d9cb69b006794ff3901ec5d50e96baa8ef  /usr/local/bin/dasel' ;; \
+      arm64) echo '92b83f30949679197403ff7a7e0f9ef3e458c1c55031d9c1bc112364e487d57d  /usr/local/bin/dasel' ;; \
     esac | sha256sum -c - && \
-    chmod +x /usr/local/bin/yq && \
-    yq --version
+    chmod +x /usr/local/bin/dasel && \
+    dasel --version
 
 RUN groupadd -r influxdb --gid=1000 && \
     useradd -r -g influxdb --uid=1000 --create-home --home-dir=/home/influxdb --shell=/bin/bash influxdb

--- a/influxdb/2.2/alpine/Dockerfile
+++ b/influxdb/2.2/alpine/Dockerfile
@@ -8,9 +8,22 @@ RUN apk add --no-cache \
       gnupg \
       run-parts \
       su-exec \
-      tzdata \
-      yq && \
+      tzdata && \
     update-ca-certificates
+
+# Install dasel for configuration parsing
+RUN case "$(apk --print-arch)" in \
+      x86_64)  arch=amd64 ;; \
+      aarch64) arch=arm64 ;; \
+      *) echo 'Unsupported architecture' && exit 1 ;; \
+    esac && \
+    curl -fLo /usr/local/bin/dasel "https://github.com/TomWright/dasel/releases/download/v2.1.2/dasel_linux_${arch}" && \
+    case ${arch} in \
+      amd64) echo 'e4b43d8c7d76904e2401dc81de0900d9cb69b006794ff3901ec5d50e96baa8ef  /usr/local/bin/dasel' ;; \
+      arm64) echo '92b83f30949679197403ff7a7e0f9ef3e458c1c55031d9c1bc112364e487d57d  /usr/local/bin/dasel' ;; \
+    esac | sha256sum -c - && \
+    chmod +x /usr/local/bin/dasel && \
+    dasel --version
 
 RUN addgroup -S -g 1000 influxdb && \
     adduser -S -G influxdb -u 1000 -h /home/influxdb -s /bin/sh influxdb && \

--- a/influxdb/2.2/alpine/entrypoint.sh
+++ b/influxdb/2.2/alpine/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-
 ## READ ME
 ##
 ## This script handles a few use-cases:
@@ -60,6 +59,7 @@ function log () {
 # Set the global log-level for the entry-point to match the config passed to influxd.
 function set_global_log_level () {
     local level="$(influxd::config::get log-level "${@}")"
+
     if [ -z "${level}" ] || [ -z "${LOG_LEVELS[${level}]}" ]; then
       LOG_LEVEL=info
     else
@@ -128,6 +128,10 @@ function influxd::config::get()
     )
   }
 
+  #
+  # Parse Value from Arguments
+  #
+
   local primary_key="${1}" && shift
 
   # Command line arguments take precedence over all other configuration
@@ -142,6 +146,10 @@ function influxd::config::get()
     esac
   done
 
+  #
+  # Parse Value from Environment
+  #
+
   local value
   local default
 
@@ -150,34 +158,41 @@ function influxd::config::get()
   # it is possible that variable was intentionally emptied; therefore, this
   # returns nothing when empty.
   value="$(table::get "${primary_key}" ${COLUMN_ENVIRONMENT})"
-  if [[ "${!value+x}" ]] ; then
-    echo "${!value:-}" && return
+  if [[ ${!value+x} ]] ; then
+    echo "${!value}" && return
   fi
 
-  # Finally, search the configuration files. `yq` is required as the format
-  # could be json, toml, yaml, etc. If the corresponding value could not be
-  # located within the configuration files, provide the default value. This
-  # default is what `influx server-config` would display if recently
-  # initialized with `influx setup`.
-  default="$(table::get "${primary_key}" "${COLUMN_DEFAULT}")"
+  #
+  # Parse Value from Configuration
+  #
 
-  if [[ "${INFLUXD_CONFIG_PATH}" == *toml ]]
+  case ${INFLUXD_CONFIG_PATH,,} in
+    *.toml)       local influxd_config_format=toml ;;
+    *.json)       local influxd_config_format=json ;;
+    *.yaml|*.yml) local influxd_config_format=yaml ;;
+  esac
+
+  # Unfortunately, dasel does not provide a method to test for the existence
+  # of a particular key. However, it returns with an error if it attempts to
+  # delete a nonexistent key. Since dasel will automatically update the
+  # configuration file, it is passed via `STDIN` to avoid this behavior.
+  if dasel -r "${influxd_config_format}" delete "${primary_key}" <"${INFLUXD_CONFIG_PATH}" &>/dev/null
   then
-    # There are two yq projects. Unfortunately, only the python version can
-    # process toml documents and this is the go implementation. Downloading
-    # python libraries would increase the docker image size considerably.
-    # Fortunately, processing toml as props extracts most information.
-    value="$(yq -p props eval ".\"${primary_key}\" // \"${default}\"" "${INFLUXD_CONFIG_PATH}")"
+    # Unfortunately, dasel has inconsistent string displaying behavior. For
+    # yaml and toml, it will display the value without double-quotes unless
+    # the string is empty. However, for json, it always with double-quotes.
+    # This always strips the first leading and trailing double-quotes, as
+    # they are almost always not required.
+    value="$(dasel -f "${INFLUXD_CONFIG_PATH}" -s "${primary_key}")"
 
     ( # strip leading and trailing " characters
       shopt -s extglob
-
       value="${value#'"'}"
       value="${value%'"'}"
       echo "${value}"
     )
   else
-    yq eval ".\"${primary_key}\" // \"${default}\"" "${INFLUXD_CONFIG_PATH}"
+    table::get "${primary_key}" "${COLUMN_DEFAULT}"
   fi
 }
 
@@ -208,6 +223,7 @@ function create_directories () {
 # Read password and username from file to avoid unsecure env variables
 if [ -n "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}" ] && DOCKER_INFLUXDB_INIT_PASSWORD=$(cat "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}") || echo "DOCKER_INFLUXDB_INIT_PASSWORD_FILE defined, but file not existing, skipping."; fi
 if [ -n "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}" ] && DOCKER_INFLUXDB_INIT_USERNAME=$(cat "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}") || echo "DOCKER_INFLUXDB_INIT_USERNAME_FILE defined, but file not existing, skipping."; fi
+if [ -n "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}" ] && DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=$(cat "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}") || echo "DOCKER_INFLUXDB_INIT_USERNAME_FILE defined, but file not existing, skipping."; fi
 
 # List of env vars required to auto-run setup or upgrade processes.
 declare -ra REQUIRED_INIT_VARS=(
@@ -401,13 +417,24 @@ function init_influxd () {
       final_host_scheme="https"
     fi
 
+    case ${INFLUXD_CONFIG_PATH,,} in
+      *.toml)       local influxd_config_format=toml ;;
+      *.json)       local influxd_config_format=json ;;
+      *.yaml|*.yml) local influxd_config_format=yaml ;;
+    esac
+
     # Generate a config file with a known HTTP port, and TLS disabled.
     local -r init_config=/tmp/config.json
-    yq --tojson eval '
-      .http-bind-address = "'"${init_bind_addr}"'"
-        | del(.tls-cert)
-        | del(.tls-key)
-    ' ${INFLUXD_CONFIG_PATH} | tee "${init_config}"
+    (
+      dasel -r "${influxd_config_format}" -w json \
+        | dasel -r json put http-bind-address -v "${init_bind_addr}" \
+        `# insert "tls-cert" and "tls-key" so delete succeeds` \
+        | dasel -r json put tls-cert -v ''                     \
+        | dasel -r json put tls-key  -v ''                     \
+        `# delete "tls-cert" and "tls-key"` \
+        | dasel -r json delete tls-cert     \
+        | dasel -r json delete tls-key
+    ) <"${INFLUXD_CONFIG_PATH}" | tee "${init_config}"
 
     # Start influxd in the background.
     log info "booting influxd server in the background"
@@ -481,7 +508,7 @@ function main () {
     if [ -f "${BOLT_PATH}" ]; then
         log info "found existing boltdb file, skipping setup wrapper" bolt_path "${BOLT_PATH}"
     elif [ -z "${DOCKER_INFLUXDB_INIT_MODE}" ]; then
-        log warn "boltdb not found at configured path, but DOCKER_INFLUXDB_INIT_MODE not specified, skipping setup wrapper" bolt_path "${bolt_path}"
+        log warn "boltdb not found at configured path, but DOCKER_INFLUXDB_INIT_MODE not specified, skipping setup wrapper" bolt_path "${BOLT_PATH}"
     else
         init_influxd "${@}"
         # Set correct permission on volume directories again. This is necessary so that if the container was run as the
@@ -492,7 +519,6 @@ function main () {
 
     if [ "$(id -u)" = 0 ]; then
         exec su-exec influxdb "$BASH_SOURCE" "${@}"
-        return
     fi
 
     # Run influxd.

--- a/influxdb/2.3/Dockerfile
+++ b/influxdb/2.3/Dockerfile
@@ -11,19 +11,19 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install yq for configuration parsing
+# Install dasel for configuration parsing
 RUN case "$(dpkg --print-architecture)" in \
       *amd64) arch=amd64 ;; \
       *arm64) arch=arm64 ;; \
       *) echo 'Unsupported architecture' && exit 1 ;; \
     esac && \
-    curl -fLo /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v4.30.8/yq_linux_${arch}" && \
+    curl -fLo /usr/local/bin/dasel "https://github.com/TomWright/dasel/releases/download/v2.1.2/dasel_linux_${arch}" && \
     case ${arch} in \
-      amd64) echo '6c911103e0dcc54e2ba07e767d2d62bcfc77452b39ebaee45b1c46f062f4fd26 /usr/local/bin/yq' ;; \
-      arm64) echo '95092e8b5332890c46689679b5e4360d96873c025ad8bafd961688f28ea434c7 /usr/local/bin/yq' ;; \
+      amd64) echo 'e4b43d8c7d76904e2401dc81de0900d9cb69b006794ff3901ec5d50e96baa8ef  /usr/local/bin/dasel' ;; \
+      arm64) echo '92b83f30949679197403ff7a7e0f9ef3e458c1c55031d9c1bc112364e487d57d  /usr/local/bin/dasel' ;; \
     esac | sha256sum -c - && \
-    chmod +x /usr/local/bin/yq && \
-    yq --version
+    chmod +x /usr/local/bin/dasel && \
+    dasel --version
 
 RUN groupadd -r influxdb --gid=1000 && \
     useradd -r -g influxdb --uid=1000 --create-home --home-dir=/home/influxdb --shell=/bin/bash influxdb

--- a/influxdb/2.3/alpine/Dockerfile
+++ b/influxdb/2.3/alpine/Dockerfile
@@ -8,9 +8,22 @@ RUN apk add --no-cache \
       gnupg \
       run-parts \
       su-exec \
-      tzdata \
-      yq && \
+      tzdata && \
     update-ca-certificates
+
+# Install dasel for configuration parsing
+RUN case "$(apk --print-arch)" in \
+      x86_64)  arch=amd64 ;; \
+      aarch64) arch=arm64 ;; \
+      *) echo 'Unsupported architecture' && exit 1 ;; \
+    esac && \
+    curl -fLo /usr/local/bin/dasel "https://github.com/TomWright/dasel/releases/download/v2.1.2/dasel_linux_${arch}" && \
+    case ${arch} in \
+      amd64) echo 'e4b43d8c7d76904e2401dc81de0900d9cb69b006794ff3901ec5d50e96baa8ef  /usr/local/bin/dasel' ;; \
+      arm64) echo '92b83f30949679197403ff7a7e0f9ef3e458c1c55031d9c1bc112364e487d57d  /usr/local/bin/dasel' ;; \
+    esac | sha256sum -c - && \
+    chmod +x /usr/local/bin/dasel && \
+    dasel --version
 
 RUN addgroup -S -g 1000 influxdb && \
     adduser -S -G influxdb -u 1000 -h /home/influxdb -s /bin/sh influxdb && \

--- a/influxdb/2.3/alpine/entrypoint.sh
+++ b/influxdb/2.3/alpine/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-
 ## READ ME
 ##
 ## This script handles a few use-cases:
@@ -60,6 +59,7 @@ function log () {
 # Set the global log-level for the entry-point to match the config passed to influxd.
 function set_global_log_level () {
     local level="$(influxd::config::get log-level "${@}")"
+
     if [ -z "${level}" ] || [ -z "${LOG_LEVELS[${level}]}" ]; then
       LOG_LEVEL=info
     else
@@ -128,6 +128,10 @@ function influxd::config::get()
     )
   }
 
+  #
+  # Parse Value from Arguments
+  #
+
   local primary_key="${1}" && shift
 
   # Command line arguments take precedence over all other configuration
@@ -142,6 +146,10 @@ function influxd::config::get()
     esac
   done
 
+  #
+  # Parse Value from Environment
+  #
+
   local value
   local default
 
@@ -150,34 +158,41 @@ function influxd::config::get()
   # it is possible that variable was intentionally emptied; therefore, this
   # returns nothing when empty.
   value="$(table::get "${primary_key}" ${COLUMN_ENVIRONMENT})"
-  if [[ "${!value+x}" ]] ; then
-    echo "${!value:-}" && return
+  if [[ ${!value+x} ]] ; then
+    echo "${!value}" && return
   fi
 
-  # Finally, search the configuration files. `yq` is required as the format
-  # could be json, toml, yaml, etc. If the corresponding value could not be
-  # located within the configuration files, provide the default value. This
-  # default is what `influx server-config` would display if recently
-  # initialized with `influx setup`.
-  default="$(table::get "${primary_key}" "${COLUMN_DEFAULT}")"
+  #
+  # Parse Value from Configuration
+  #
 
-  if [[ "${INFLUXD_CONFIG_PATH}" == *toml ]]
+  case ${INFLUXD_CONFIG_PATH,,} in
+    *.toml)       local influxd_config_format=toml ;;
+    *.json)       local influxd_config_format=json ;;
+    *.yaml|*.yml) local influxd_config_format=yaml ;;
+  esac
+
+  # Unfortunately, dasel does not provide a method to test for the existence
+  # of a particular key. However, it returns with an error if it attempts to
+  # delete a nonexistent key. Since dasel will automatically update the
+  # configuration file, it is passed via `STDIN` to avoid this behavior.
+  if dasel -r "${influxd_config_format}" delete "${primary_key}" <"${INFLUXD_CONFIG_PATH}" &>/dev/null
   then
-    # There are two yq projects. Unfortunately, only the python version can
-    # process toml documents and this is the go implementation. Downloading
-    # python libraries would increase the docker image size considerably.
-    # Fortunately, processing toml as props extracts most information.
-    value="$(yq -p props eval ".\"${primary_key}\" // \"${default}\"" "${INFLUXD_CONFIG_PATH}")"
+    # Unfortunately, dasel has inconsistent string displaying behavior. For
+    # yaml and toml, it will display the value without double-quotes unless
+    # the string is empty. However, for json, it always with double-quotes.
+    # This always strips the first leading and trailing double-quotes, as
+    # they are almost always not required.
+    value="$(dasel -f "${INFLUXD_CONFIG_PATH}" -s "${primary_key}")"
 
     ( # strip leading and trailing " characters
       shopt -s extglob
-
       value="${value#'"'}"
       value="${value%'"'}"
       echo "${value}"
     )
   else
-    yq eval ".\"${primary_key}\" // \"${default}\"" "${INFLUXD_CONFIG_PATH}"
+    table::get "${primary_key}" "${COLUMN_DEFAULT}"
   fi
 }
 
@@ -208,6 +223,7 @@ function create_directories () {
 # Read password and username from file to avoid unsecure env variables
 if [ -n "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}" ] && DOCKER_INFLUXDB_INIT_PASSWORD=$(cat "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}") || echo "DOCKER_INFLUXDB_INIT_PASSWORD_FILE defined, but file not existing, skipping."; fi
 if [ -n "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}" ] && DOCKER_INFLUXDB_INIT_USERNAME=$(cat "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}") || echo "DOCKER_INFLUXDB_INIT_USERNAME_FILE defined, but file not existing, skipping."; fi
+if [ -n "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}" ] && DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=$(cat "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}") || echo "DOCKER_INFLUXDB_INIT_USERNAME_FILE defined, but file not existing, skipping."; fi
 
 # List of env vars required to auto-run setup or upgrade processes.
 declare -ra REQUIRED_INIT_VARS=(
@@ -401,13 +417,24 @@ function init_influxd () {
       final_host_scheme="https"
     fi
 
+    case ${INFLUXD_CONFIG_PATH,,} in
+      *.toml)       local influxd_config_format=toml ;;
+      *.json)       local influxd_config_format=json ;;
+      *.yaml|*.yml) local influxd_config_format=yaml ;;
+    esac
+
     # Generate a config file with a known HTTP port, and TLS disabled.
     local -r init_config=/tmp/config.json
-    yq --tojson eval '
-      .http-bind-address = "'"${init_bind_addr}"'"
-        | del(.tls-cert)
-        | del(.tls-key)
-    ' ${INFLUXD_CONFIG_PATH} | tee "${init_config}"
+    (
+      dasel -r "${influxd_config_format}" -w json \
+        | dasel -r json put http-bind-address -v "${init_bind_addr}" \
+        `# insert "tls-cert" and "tls-key" so delete succeeds` \
+        | dasel -r json put tls-cert -v ''                     \
+        | dasel -r json put tls-key  -v ''                     \
+        `# delete "tls-cert" and "tls-key"` \
+        | dasel -r json delete tls-cert     \
+        | dasel -r json delete tls-key
+    ) <"${INFLUXD_CONFIG_PATH}" | tee "${init_config}"
 
     # Start influxd in the background.
     log info "booting influxd server in the background"
@@ -481,7 +508,7 @@ function main () {
     if [ -f "${BOLT_PATH}" ]; then
         log info "found existing boltdb file, skipping setup wrapper" bolt_path "${BOLT_PATH}"
     elif [ -z "${DOCKER_INFLUXDB_INIT_MODE}" ]; then
-        log warn "boltdb not found at configured path, but DOCKER_INFLUXDB_INIT_MODE not specified, skipping setup wrapper" bolt_path "${bolt_path}"
+        log warn "boltdb not found at configured path, but DOCKER_INFLUXDB_INIT_MODE not specified, skipping setup wrapper" bolt_path "${BOLT_PATH}"
     else
         init_influxd "${@}"
         # Set correct permission on volume directories again. This is necessary so that if the container was run as the
@@ -492,7 +519,6 @@ function main () {
 
     if [ "$(id -u)" = 0 ]; then
         exec su-exec influxdb "$BASH_SOURCE" "${@}"
-        return
     fi
 
     # Run influxd.

--- a/influxdb/2.4/Dockerfile
+++ b/influxdb/2.4/Dockerfile
@@ -11,19 +11,19 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install yq for configuration parsing
+# Install dasel for configuration parsing
 RUN case "$(dpkg --print-architecture)" in \
       *amd64) arch=amd64 ;; \
       *arm64) arch=arm64 ;; \
       *) echo 'Unsupported architecture' && exit 1 ;; \
     esac && \
-    curl -fLo /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v4.30.8/yq_linux_${arch}" && \
+    curl -fLo /usr/local/bin/dasel "https://github.com/TomWright/dasel/releases/download/v2.1.2/dasel_linux_${arch}" && \
     case ${arch} in \
-      amd64) echo '6c911103e0dcc54e2ba07e767d2d62bcfc77452b39ebaee45b1c46f062f4fd26 /usr/local/bin/yq' ;; \
-      arm64) echo '95092e8b5332890c46689679b5e4360d96873c025ad8bafd961688f28ea434c7 /usr/local/bin/yq' ;; \
+      amd64) echo 'e4b43d8c7d76904e2401dc81de0900d9cb69b006794ff3901ec5d50e96baa8ef  /usr/local/bin/dasel' ;; \
+      arm64) echo '92b83f30949679197403ff7a7e0f9ef3e458c1c55031d9c1bc112364e487d57d  /usr/local/bin/dasel' ;; \
     esac | sha256sum -c - && \
-    chmod +x /usr/local/bin/yq && \
-    yq --version
+    chmod +x /usr/local/bin/dasel && \
+    dasel --version
 
 RUN groupadd -r influxdb --gid=1000 && \
     useradd -r -g influxdb --uid=1000 --create-home --home-dir=/home/influxdb --shell=/bin/bash influxdb

--- a/influxdb/2.4/alpine/Dockerfile
+++ b/influxdb/2.4/alpine/Dockerfile
@@ -8,9 +8,22 @@ RUN apk add --no-cache \
       gnupg \
       run-parts \
       su-exec \
-      tzdata \
-      yq && \
+      tzdata && \
     update-ca-certificates
+
+# Install dasel for configuration parsing
+RUN case "$(apk --print-arch)" in \
+      x86_64)  arch=amd64 ;; \
+      aarch64) arch=arm64 ;; \
+      *) echo 'Unsupported architecture' && exit 1 ;; \
+    esac && \
+    curl -fLo /usr/local/bin/dasel "https://github.com/TomWright/dasel/releases/download/v2.1.2/dasel_linux_${arch}" && \
+    case ${arch} in \
+      amd64) echo 'e4b43d8c7d76904e2401dc81de0900d9cb69b006794ff3901ec5d50e96baa8ef  /usr/local/bin/dasel' ;; \
+      arm64) echo '92b83f30949679197403ff7a7e0f9ef3e458c1c55031d9c1bc112364e487d57d  /usr/local/bin/dasel' ;; \
+    esac | sha256sum -c - && \
+    chmod +x /usr/local/bin/dasel && \
+    dasel --version
 
 RUN addgroup -S -g 1000 influxdb && \
     adduser -S -G influxdb -u 1000 -h /home/influxdb -s /bin/sh influxdb && \

--- a/influxdb/2.4/alpine/entrypoint.sh
+++ b/influxdb/2.4/alpine/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-
 ## READ ME
 ##
 ## This script handles a few use-cases:
@@ -60,6 +59,7 @@ function log () {
 # Set the global log-level for the entry-point to match the config passed to influxd.
 function set_global_log_level () {
     local level="$(influxd::config::get log-level "${@}")"
+
     if [ -z "${level}" ] || [ -z "${LOG_LEVELS[${level}]}" ]; then
       LOG_LEVEL=info
     else
@@ -128,6 +128,10 @@ function influxd::config::get()
     )
   }
 
+  #
+  # Parse Value from Arguments
+  #
+
   local primary_key="${1}" && shift
 
   # Command line arguments take precedence over all other configuration
@@ -142,6 +146,10 @@ function influxd::config::get()
     esac
   done
 
+  #
+  # Parse Value from Environment
+  #
+
   local value
   local default
 
@@ -150,34 +158,41 @@ function influxd::config::get()
   # it is possible that variable was intentionally emptied; therefore, this
   # returns nothing when empty.
   value="$(table::get "${primary_key}" ${COLUMN_ENVIRONMENT})"
-  if [[ "${!value+x}" ]] ; then
-    echo "${!value:-}" && return
+  if [[ ${!value+x} ]] ; then
+    echo "${!value}" && return
   fi
 
-  # Finally, search the configuration files. `yq` is required as the format
-  # could be json, toml, yaml, etc. If the corresponding value could not be
-  # located within the configuration files, provide the default value. This
-  # default is what `influx server-config` would display if recently
-  # initialized with `influx setup`.
-  default="$(table::get "${primary_key}" "${COLUMN_DEFAULT}")"
+  #
+  # Parse Value from Configuration
+  #
 
-  if [[ "${INFLUXD_CONFIG_PATH}" == *toml ]]
+  case ${INFLUXD_CONFIG_PATH,,} in
+    *.toml)       local influxd_config_format=toml ;;
+    *.json)       local influxd_config_format=json ;;
+    *.yaml|*.yml) local influxd_config_format=yaml ;;
+  esac
+
+  # Unfortunately, dasel does not provide a method to test for the existence
+  # of a particular key. However, it returns with an error if it attempts to
+  # delete a nonexistent key. Since dasel will automatically update the
+  # configuration file, it is passed via `STDIN` to avoid this behavior.
+  if dasel -r "${influxd_config_format}" delete "${primary_key}" <"${INFLUXD_CONFIG_PATH}" &>/dev/null
   then
-    # There are two yq projects. Unfortunately, only the python version can
-    # process toml documents and this is the go implementation. Downloading
-    # python libraries would increase the docker image size considerably.
-    # Fortunately, processing toml as props extracts most information.
-    value="$(yq -p props eval ".\"${primary_key}\" // \"${default}\"" "${INFLUXD_CONFIG_PATH}")"
+    # Unfortunately, dasel has inconsistent string displaying behavior. For
+    # yaml and toml, it will display the value without double-quotes unless
+    # the string is empty. However, for json, it always with double-quotes.
+    # This always strips the first leading and trailing double-quotes, as
+    # they are almost always not required.
+    value="$(dasel -f "${INFLUXD_CONFIG_PATH}" -s "${primary_key}")"
 
     ( # strip leading and trailing " characters
       shopt -s extglob
-
       value="${value#'"'}"
       value="${value%'"'}"
       echo "${value}"
     )
   else
-    yq eval ".\"${primary_key}\" // \"${default}\"" "${INFLUXD_CONFIG_PATH}"
+    table::get "${primary_key}" "${COLUMN_DEFAULT}"
   fi
 }
 
@@ -208,6 +223,7 @@ function create_directories () {
 # Read password and username from file to avoid unsecure env variables
 if [ -n "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}" ] && DOCKER_INFLUXDB_INIT_PASSWORD=$(cat "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}") || echo "DOCKER_INFLUXDB_INIT_PASSWORD_FILE defined, but file not existing, skipping."; fi
 if [ -n "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}" ] && DOCKER_INFLUXDB_INIT_USERNAME=$(cat "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}") || echo "DOCKER_INFLUXDB_INIT_USERNAME_FILE defined, but file not existing, skipping."; fi
+if [ -n "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}" ] && DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=$(cat "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}") || echo "DOCKER_INFLUXDB_INIT_USERNAME_FILE defined, but file not existing, skipping."; fi
 
 # List of env vars required to auto-run setup or upgrade processes.
 declare -ra REQUIRED_INIT_VARS=(
@@ -401,13 +417,24 @@ function init_influxd () {
       final_host_scheme="https"
     fi
 
+    case ${INFLUXD_CONFIG_PATH,,} in
+      *.toml)       local influxd_config_format=toml ;;
+      *.json)       local influxd_config_format=json ;;
+      *.yaml|*.yml) local influxd_config_format=yaml ;;
+    esac
+
     # Generate a config file with a known HTTP port, and TLS disabled.
     local -r init_config=/tmp/config.json
-    yq --tojson eval '
-      .http-bind-address = "'"${init_bind_addr}"'"
-        | del(.tls-cert)
-        | del(.tls-key)
-    ' ${INFLUXD_CONFIG_PATH} | tee "${init_config}"
+    (
+      dasel -r "${influxd_config_format}" -w json \
+        | dasel -r json put http-bind-address -v "${init_bind_addr}" \
+        `# insert "tls-cert" and "tls-key" so delete succeeds` \
+        | dasel -r json put tls-cert -v ''                     \
+        | dasel -r json put tls-key  -v ''                     \
+        `# delete "tls-cert" and "tls-key"` \
+        | dasel -r json delete tls-cert     \
+        | dasel -r json delete tls-key
+    ) <"${INFLUXD_CONFIG_PATH}" | tee "${init_config}"
 
     # Start influxd in the background.
     log info "booting influxd server in the background"
@@ -481,7 +508,7 @@ function main () {
     if [ -f "${BOLT_PATH}" ]; then
         log info "found existing boltdb file, skipping setup wrapper" bolt_path "${BOLT_PATH}"
     elif [ -z "${DOCKER_INFLUXDB_INIT_MODE}" ]; then
-        log warn "boltdb not found at configured path, but DOCKER_INFLUXDB_INIT_MODE not specified, skipping setup wrapper" bolt_path "${bolt_path}"
+        log warn "boltdb not found at configured path, but DOCKER_INFLUXDB_INIT_MODE not specified, skipping setup wrapper" bolt_path "${BOLT_PATH}"
     else
         init_influxd "${@}"
         # Set correct permission on volume directories again. This is necessary so that if the container was run as the
@@ -492,7 +519,6 @@ function main () {
 
     if [ "$(id -u)" = 0 ]; then
         exec su-exec influxdb "$BASH_SOURCE" "${@}"
-        return
     fi
 
     # Run influxd.

--- a/influxdb/2.5/Dockerfile
+++ b/influxdb/2.5/Dockerfile
@@ -11,19 +11,19 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install yq for configuration parsing
+# Install dasel for configuration parsing
 RUN case "$(dpkg --print-architecture)" in \
       *amd64) arch=amd64 ;; \
       *arm64) arch=arm64 ;; \
       *) echo 'Unsupported architecture' && exit 1 ;; \
     esac && \
-    curl -fLo /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v4.30.8/yq_linux_${arch}" && \
+    curl -fLo /usr/local/bin/dasel "https://github.com/TomWright/dasel/releases/download/v2.1.2/dasel_linux_${arch}" && \
     case ${arch} in \
-      amd64) echo '6c911103e0dcc54e2ba07e767d2d62bcfc77452b39ebaee45b1c46f062f4fd26 /usr/local/bin/yq' ;; \
-      arm64) echo '95092e8b5332890c46689679b5e4360d96873c025ad8bafd961688f28ea434c7 /usr/local/bin/yq' ;; \
+      amd64) echo 'e4b43d8c7d76904e2401dc81de0900d9cb69b006794ff3901ec5d50e96baa8ef  /usr/local/bin/dasel' ;; \
+      arm64) echo '92b83f30949679197403ff7a7e0f9ef3e458c1c55031d9c1bc112364e487d57d  /usr/local/bin/dasel' ;; \
     esac | sha256sum -c - && \
-    chmod +x /usr/local/bin/yq && \
-    yq --version
+    chmod +x /usr/local/bin/dasel && \
+    dasel --version
 
 RUN groupadd -r influxdb --gid=1000 && \
     useradd -r -g influxdb --uid=1000 --create-home --home-dir=/home/influxdb --shell=/bin/bash influxdb

--- a/influxdb/2.5/alpine/Dockerfile
+++ b/influxdb/2.5/alpine/Dockerfile
@@ -8,9 +8,22 @@ RUN apk add --no-cache \
       gnupg \
       run-parts \
       su-exec \
-      tzdata \
-      yq && \
+      tzdata && \
     update-ca-certificates
+
+# Install dasel for configuration parsing
+RUN case "$(apk --print-arch)" in \
+      x86_64)  arch=amd64 ;; \
+      aarch64) arch=arm64 ;; \
+      *) echo 'Unsupported architecture' && exit 1 ;; \
+    esac && \
+    curl -fLo /usr/local/bin/dasel "https://github.com/TomWright/dasel/releases/download/v2.1.2/dasel_linux_${arch}" && \
+    case ${arch} in \
+      amd64) echo 'e4b43d8c7d76904e2401dc81de0900d9cb69b006794ff3901ec5d50e96baa8ef  /usr/local/bin/dasel' ;; \
+      arm64) echo '92b83f30949679197403ff7a7e0f9ef3e458c1c55031d9c1bc112364e487d57d  /usr/local/bin/dasel' ;; \
+    esac | sha256sum -c - && \
+    chmod +x /usr/local/bin/dasel && \
+    dasel --version
 
 RUN addgroup -S -g 1000 influxdb && \
     adduser -S -G influxdb -u 1000 -h /home/influxdb -s /bin/sh influxdb && \

--- a/influxdb/2.5/alpine/entrypoint.sh
+++ b/influxdb/2.5/alpine/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-
 ## READ ME
 ##
 ## This script handles a few use-cases:
@@ -60,6 +59,7 @@ function log () {
 # Set the global log-level for the entry-point to match the config passed to influxd.
 function set_global_log_level () {
     local level="$(influxd::config::get log-level "${@}")"
+
     if [ -z "${level}" ] || [ -z "${LOG_LEVELS[${level}]}" ]; then
       LOG_LEVEL=info
     else
@@ -128,6 +128,10 @@ function influxd::config::get()
     )
   }
 
+  #
+  # Parse Value from Arguments
+  #
+
   local primary_key="${1}" && shift
 
   # Command line arguments take precedence over all other configuration
@@ -142,6 +146,10 @@ function influxd::config::get()
     esac
   done
 
+  #
+  # Parse Value from Environment
+  #
+
   local value
   local default
 
@@ -150,34 +158,41 @@ function influxd::config::get()
   # it is possible that variable was intentionally emptied; therefore, this
   # returns nothing when empty.
   value="$(table::get "${primary_key}" ${COLUMN_ENVIRONMENT})"
-  if [[ "${!value+x}" ]] ; then
-    echo "${!value:-}" && return
+  if [[ ${!value+x} ]] ; then
+    echo "${!value}" && return
   fi
 
-  # Finally, search the configuration files. `yq` is required as the format
-  # could be json, toml, yaml, etc. If the corresponding value could not be
-  # located within the configuration files, provide the default value. This
-  # default is what `influx server-config` would display if recently
-  # initialized with `influx setup`.
-  default="$(table::get "${primary_key}" "${COLUMN_DEFAULT}")"
+  #
+  # Parse Value from Configuration
+  #
 
-  if [[ "${INFLUXD_CONFIG_PATH}" == *toml ]]
+  case ${INFLUXD_CONFIG_PATH,,} in
+    *.toml)       local influxd_config_format=toml ;;
+    *.json)       local influxd_config_format=json ;;
+    *.yaml|*.yml) local influxd_config_format=yaml ;;
+  esac
+
+  # Unfortunately, dasel does not provide a method to test for the existence
+  # of a particular key. However, it returns with an error if it attempts to
+  # delete a nonexistent key. Since dasel will automatically update the
+  # configuration file, it is passed via `STDIN` to avoid this behavior.
+  if dasel -r "${influxd_config_format}" delete "${primary_key}" <"${INFLUXD_CONFIG_PATH}" &>/dev/null
   then
-    # There are two yq projects. Unfortunately, only the python version can
-    # process toml documents and this is the go implementation. Downloading
-    # python libraries would increase the docker image size considerably.
-    # Fortunately, processing toml as props extracts most information.
-    value="$(yq -p props eval ".\"${primary_key}\" // \"${default}\"" "${INFLUXD_CONFIG_PATH}")"
+    # Unfortunately, dasel has inconsistent string displaying behavior. For
+    # yaml and toml, it will display the value without double-quotes unless
+    # the string is empty. However, for json, it always with double-quotes.
+    # This always strips the first leading and trailing double-quotes, as
+    # they are almost always not required.
+    value="$(dasel -f "${INFLUXD_CONFIG_PATH}" -s "${primary_key}")"
 
     ( # strip leading and trailing " characters
       shopt -s extglob
-
       value="${value#'"'}"
       value="${value%'"'}"
       echo "${value}"
     )
   else
-    yq eval ".\"${primary_key}\" // \"${default}\"" "${INFLUXD_CONFIG_PATH}"
+    table::get "${primary_key}" "${COLUMN_DEFAULT}"
   fi
 }
 
@@ -208,6 +223,7 @@ function create_directories () {
 # Read password and username from file to avoid unsecure env variables
 if [ -n "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}" ] && DOCKER_INFLUXDB_INIT_PASSWORD=$(cat "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}") || echo "DOCKER_INFLUXDB_INIT_PASSWORD_FILE defined, but file not existing, skipping."; fi
 if [ -n "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}" ] && DOCKER_INFLUXDB_INIT_USERNAME=$(cat "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}") || echo "DOCKER_INFLUXDB_INIT_USERNAME_FILE defined, but file not existing, skipping."; fi
+if [ -n "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}" ] && DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=$(cat "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}") || echo "DOCKER_INFLUXDB_INIT_USERNAME_FILE defined, but file not existing, skipping."; fi
 
 # List of env vars required to auto-run setup or upgrade processes.
 declare -ra REQUIRED_INIT_VARS=(
@@ -401,13 +417,24 @@ function init_influxd () {
       final_host_scheme="https"
     fi
 
+    case ${INFLUXD_CONFIG_PATH,,} in
+      *.toml)       local influxd_config_format=toml ;;
+      *.json)       local influxd_config_format=json ;;
+      *.yaml|*.yml) local influxd_config_format=yaml ;;
+    esac
+
     # Generate a config file with a known HTTP port, and TLS disabled.
     local -r init_config=/tmp/config.json
-    yq --tojson eval '
-      .http-bind-address = "'"${init_bind_addr}"'"
-        | del(.tls-cert)
-        | del(.tls-key)
-    ' ${INFLUXD_CONFIG_PATH} | tee "${init_config}"
+    (
+      dasel -r "${influxd_config_format}" -w json \
+        | dasel -r json put http-bind-address -v "${init_bind_addr}" \
+        `# insert "tls-cert" and "tls-key" so delete succeeds` \
+        | dasel -r json put tls-cert -v ''                     \
+        | dasel -r json put tls-key  -v ''                     \
+        `# delete "tls-cert" and "tls-key"` \
+        | dasel -r json delete tls-cert     \
+        | dasel -r json delete tls-key
+    ) <"${INFLUXD_CONFIG_PATH}" | tee "${init_config}"
 
     # Start influxd in the background.
     log info "booting influxd server in the background"
@@ -481,7 +508,7 @@ function main () {
     if [ -f "${BOLT_PATH}" ]; then
         log info "found existing boltdb file, skipping setup wrapper" bolt_path "${BOLT_PATH}"
     elif [ -z "${DOCKER_INFLUXDB_INIT_MODE}" ]; then
-        log warn "boltdb not found at configured path, but DOCKER_INFLUXDB_INIT_MODE not specified, skipping setup wrapper" bolt_path "${bolt_path}"
+        log warn "boltdb not found at configured path, but DOCKER_INFLUXDB_INIT_MODE not specified, skipping setup wrapper" bolt_path "${BOLT_PATH}"
     else
         init_influxd "${@}"
         # Set correct permission on volume directories again. This is necessary so that if the container was run as the
@@ -492,7 +519,6 @@ function main () {
 
     if [ "$(id -u)" = 0 ]; then
         exec su-exec influxdb "$BASH_SOURCE" "${@}"
-        return
     fi
 
     # Run influxd.

--- a/influxdb/2.6/Dockerfile
+++ b/influxdb/2.6/Dockerfile
@@ -11,19 +11,19 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install yq for configuration parsing
+# Install dasel for configuration parsing
 RUN case "$(dpkg --print-architecture)" in \
       *amd64) arch=amd64 ;; \
       *arm64) arch=arm64 ;; \
       *) echo 'Unsupported architecture' && exit 1 ;; \
     esac && \
-    curl -fLo /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v4.30.8/yq_linux_${arch}" && \
+    curl -fLo /usr/local/bin/dasel "https://github.com/TomWright/dasel/releases/download/v2.1.2/dasel_linux_${arch}" && \
     case ${arch} in \
-      amd64) echo '6c911103e0dcc54e2ba07e767d2d62bcfc77452b39ebaee45b1c46f062f4fd26 /usr/local/bin/yq' ;; \
-      arm64) echo '95092e8b5332890c46689679b5e4360d96873c025ad8bafd961688f28ea434c7 /usr/local/bin/yq' ;; \
+      amd64) echo 'e4b43d8c7d76904e2401dc81de0900d9cb69b006794ff3901ec5d50e96baa8ef  /usr/local/bin/dasel' ;; \
+      arm64) echo '92b83f30949679197403ff7a7e0f9ef3e458c1c55031d9c1bc112364e487d57d  /usr/local/bin/dasel' ;; \
     esac | sha256sum -c - && \
-    chmod +x /usr/local/bin/yq && \
-    yq --version
+    chmod +x /usr/local/bin/dasel && \
+    dasel --version
 
 RUN groupadd -r influxdb --gid=1000 && \
     useradd -r -g influxdb --uid=1000 --create-home --home-dir=/home/influxdb --shell=/bin/bash influxdb

--- a/influxdb/2.6/alpine/Dockerfile
+++ b/influxdb/2.6/alpine/Dockerfile
@@ -8,9 +8,22 @@ RUN apk add --no-cache \
       gnupg \
       run-parts \
       su-exec \
-      tzdata \
-      yq && \
+      tzdata && \
     update-ca-certificates
+
+# Install dasel for configuration parsing
+RUN case "$(apk --print-arch)" in \
+      x86_64)  arch=amd64 ;; \
+      aarch64) arch=arm64 ;; \
+      *) echo 'Unsupported architecture' && exit 1 ;; \
+    esac && \
+    curl -fLo /usr/local/bin/dasel "https://github.com/TomWright/dasel/releases/download/v2.1.2/dasel_linux_${arch}" && \
+    case ${arch} in \
+      amd64) echo 'e4b43d8c7d76904e2401dc81de0900d9cb69b006794ff3901ec5d50e96baa8ef  /usr/local/bin/dasel' ;; \
+      arm64) echo '92b83f30949679197403ff7a7e0f9ef3e458c1c55031d9c1bc112364e487d57d  /usr/local/bin/dasel' ;; \
+    esac | sha256sum -c - && \
+    chmod +x /usr/local/bin/dasel && \
+    dasel --version
 
 RUN addgroup -S -g 1000 influxdb && \
     adduser -S -G influxdb -u 1000 -h /home/influxdb -s /bin/sh influxdb && \

--- a/influxdb/2.6/alpine/entrypoint.sh
+++ b/influxdb/2.6/alpine/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-
 ## READ ME
 ##
 ## This script handles a few use-cases:
@@ -60,6 +59,7 @@ function log () {
 # Set the global log-level for the entry-point to match the config passed to influxd.
 function set_global_log_level () {
     local level="$(influxd::config::get log-level "${@}")"
+
     if [ -z "${level}" ] || [ -z "${LOG_LEVELS[${level}]}" ]; then
       LOG_LEVEL=info
     else
@@ -128,6 +128,10 @@ function influxd::config::get()
     )
   }
 
+  #
+  # Parse Value from Arguments
+  #
+
   local primary_key="${1}" && shift
 
   # Command line arguments take precedence over all other configuration
@@ -142,6 +146,10 @@ function influxd::config::get()
     esac
   done
 
+  #
+  # Parse Value from Environment
+  #
+
   local value
   local default
 
@@ -150,34 +158,41 @@ function influxd::config::get()
   # it is possible that variable was intentionally emptied; therefore, this
   # returns nothing when empty.
   value="$(table::get "${primary_key}" ${COLUMN_ENVIRONMENT})"
-  if [[ "${!value+x}" ]] ; then
-    echo "${!value:-}" && return
+  if [[ ${!value+x} ]] ; then
+    echo "${!value}" && return
   fi
 
-  # Finally, search the configuration files. `yq` is required as the format
-  # could be json, toml, yaml, etc. If the corresponding value could not be
-  # located within the configuration files, provide the default value. This
-  # default is what `influx server-config` would display if recently
-  # initialized with `influx setup`.
-  default="$(table::get "${primary_key}" "${COLUMN_DEFAULT}")"
+  #
+  # Parse Value from Configuration
+  #
 
-  if [[ "${INFLUXD_CONFIG_PATH}" == *toml ]]
+  case ${INFLUXD_CONFIG_PATH,,} in
+    *.toml)       local influxd_config_format=toml ;;
+    *.json)       local influxd_config_format=json ;;
+    *.yaml|*.yml) local influxd_config_format=yaml ;;
+  esac
+
+  # Unfortunately, dasel does not provide a method to test for the existence
+  # of a particular key. However, it returns with an error if it attempts to
+  # delete a nonexistent key. Since dasel will automatically update the
+  # configuration file, it is passed via `STDIN` to avoid this behavior.
+  if dasel -r "${influxd_config_format}" delete "${primary_key}" <"${INFLUXD_CONFIG_PATH}" &>/dev/null
   then
-    # There are two yq projects. Unfortunately, only the python version can
-    # process toml documents and this is the go implementation. Downloading
-    # python libraries would increase the docker image size considerably.
-    # Fortunately, processing toml as props extracts most information.
-    value="$(yq -p props eval ".\"${primary_key}\" // \"${default}\"" "${INFLUXD_CONFIG_PATH}")"
+    # Unfortunately, dasel has inconsistent string displaying behavior. For
+    # yaml and toml, it will display the value without double-quotes unless
+    # the string is empty. However, for json, it always with double-quotes.
+    # This always strips the first leading and trailing double-quotes, as
+    # they are almost always not required.
+    value="$(dasel -f "${INFLUXD_CONFIG_PATH}" -s "${primary_key}")"
 
     ( # strip leading and trailing " characters
       shopt -s extglob
-
       value="${value#'"'}"
       value="${value%'"'}"
       echo "${value}"
     )
   else
-    yq eval ".\"${primary_key}\" // \"${default}\"" "${INFLUXD_CONFIG_PATH}"
+    table::get "${primary_key}" "${COLUMN_DEFAULT}"
   fi
 }
 
@@ -208,6 +223,7 @@ function create_directories () {
 # Read password and username from file to avoid unsecure env variables
 if [ -n "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}" ] && DOCKER_INFLUXDB_INIT_PASSWORD=$(cat "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}") || echo "DOCKER_INFLUXDB_INIT_PASSWORD_FILE defined, but file not existing, skipping."; fi
 if [ -n "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}" ] && DOCKER_INFLUXDB_INIT_USERNAME=$(cat "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}") || echo "DOCKER_INFLUXDB_INIT_USERNAME_FILE defined, but file not existing, skipping."; fi
+if [ -n "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}" ] && DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=$(cat "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}") || echo "DOCKER_INFLUXDB_INIT_USERNAME_FILE defined, but file not existing, skipping."; fi
 
 # List of env vars required to auto-run setup or upgrade processes.
 declare -ra REQUIRED_INIT_VARS=(
@@ -401,13 +417,24 @@ function init_influxd () {
       final_host_scheme="https"
     fi
 
+    case ${INFLUXD_CONFIG_PATH,,} in
+      *.toml)       local influxd_config_format=toml ;;
+      *.json)       local influxd_config_format=json ;;
+      *.yaml|*.yml) local influxd_config_format=yaml ;;
+    esac
+
     # Generate a config file with a known HTTP port, and TLS disabled.
     local -r init_config=/tmp/config.json
-    yq --tojson eval '
-      .http-bind-address = "'"${init_bind_addr}"'"
-        | del(.tls-cert)
-        | del(.tls-key)
-    ' ${INFLUXD_CONFIG_PATH} | tee "${init_config}"
+    (
+      dasel -r "${influxd_config_format}" -w json \
+        | dasel -r json put http-bind-address -v "${init_bind_addr}" \
+        `# insert "tls-cert" and "tls-key" so delete succeeds` \
+        | dasel -r json put tls-cert -v ''                     \
+        | dasel -r json put tls-key  -v ''                     \
+        `# delete "tls-cert" and "tls-key"` \
+        | dasel -r json delete tls-cert     \
+        | dasel -r json delete tls-key
+    ) <"${INFLUXD_CONFIG_PATH}" | tee "${init_config}"
 
     # Start influxd in the background.
     log info "booting influxd server in the background"
@@ -481,7 +508,7 @@ function main () {
     if [ -f "${BOLT_PATH}" ]; then
         log info "found existing boltdb file, skipping setup wrapper" bolt_path "${BOLT_PATH}"
     elif [ -z "${DOCKER_INFLUXDB_INIT_MODE}" ]; then
-        log warn "boltdb not found at configured path, but DOCKER_INFLUXDB_INIT_MODE not specified, skipping setup wrapper" bolt_path "${bolt_path}"
+        log warn "boltdb not found at configured path, but DOCKER_INFLUXDB_INIT_MODE not specified, skipping setup wrapper" bolt_path "${BOLT_PATH}"
     else
         init_influxd "${@}"
         # Set correct permission on volume directories again. This is necessary so that if the container was run as the
@@ -492,7 +519,6 @@ function main () {
 
     if [ "$(id -u)" = 0 ]; then
         exec su-exec influxdb "$BASH_SOURCE" "${@}"
-        return
     fi
 
     # Run influxd.

--- a/influxdb/2.7/Dockerfile
+++ b/influxdb/2.7/Dockerfile
@@ -11,19 +11,19 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install yq for configuration parsing
+# Install dasel for configuration parsing
 RUN case "$(dpkg --print-architecture)" in \
       *amd64) arch=amd64 ;; \
       *arm64) arch=arm64 ;; \
       *) echo 'Unsupported architecture' && exit 1 ;; \
     esac && \
-    curl -fLo /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v4.30.8/yq_linux_${arch}" && \
+    curl -fLo /usr/local/bin/dasel "https://github.com/TomWright/dasel/releases/download/v2.1.2/dasel_linux_${arch}" && \
     case ${arch} in \
-      amd64) echo '6c911103e0dcc54e2ba07e767d2d62bcfc77452b39ebaee45b1c46f062f4fd26 /usr/local/bin/yq' ;; \
-      arm64) echo '95092e8b5332890c46689679b5e4360d96873c025ad8bafd961688f28ea434c7 /usr/local/bin/yq' ;; \
+      amd64) echo 'e4b43d8c7d76904e2401dc81de0900d9cb69b006794ff3901ec5d50e96baa8ef  /usr/local/bin/dasel' ;; \
+      arm64) echo '92b83f30949679197403ff7a7e0f9ef3e458c1c55031d9c1bc112364e487d57d  /usr/local/bin/dasel' ;; \
     esac | sha256sum -c - && \
-    chmod +x /usr/local/bin/yq && \
-    yq --version
+    chmod +x /usr/local/bin/dasel && \
+    dasel --version
 
 RUN groupadd -r influxdb --gid=1000 && \
     useradd -r -g influxdb --uid=1000 --create-home --home-dir=/home/influxdb --shell=/bin/bash influxdb

--- a/influxdb/2.7/alpine/Dockerfile
+++ b/influxdb/2.7/alpine/Dockerfile
@@ -8,9 +8,22 @@ RUN apk add --no-cache \
       gnupg \
       run-parts \
       su-exec \
-      tzdata \
-      yq && \
+      tzdata && \
     update-ca-certificates
+
+# Install dasel for configuration parsing
+RUN case "$(apk --print-arch)" in \
+      x86_64)  arch=amd64 ;; \
+      aarch64) arch=arm64 ;; \
+      *) echo 'Unsupported architecture' && exit 1 ;; \
+    esac && \
+    curl -fLo /usr/local/bin/dasel "https://github.com/TomWright/dasel/releases/download/v2.1.2/dasel_linux_${arch}" && \
+    case ${arch} in \
+      amd64) echo 'e4b43d8c7d76904e2401dc81de0900d9cb69b006794ff3901ec5d50e96baa8ef  /usr/local/bin/dasel' ;; \
+      arm64) echo '92b83f30949679197403ff7a7e0f9ef3e458c1c55031d9c1bc112364e487d57d  /usr/local/bin/dasel' ;; \
+    esac | sha256sum -c - && \
+    chmod +x /usr/local/bin/dasel && \
+    dasel --version
 
 RUN addgroup -S -g 1000 influxdb && \
     adduser -S -G influxdb -u 1000 -h /home/influxdb -s /bin/sh influxdb && \

--- a/influxdb/2.7/alpine/entrypoint.sh
+++ b/influxdb/2.7/alpine/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-
 ## READ ME
 ##
 ## This script handles a few use-cases:
@@ -60,6 +59,7 @@ function log () {
 # Set the global log-level for the entry-point to match the config passed to influxd.
 function set_global_log_level () {
     local level="$(influxd::config::get log-level "${@}")"
+
     if [ -z "${level}" ] || [ -z "${LOG_LEVELS[${level}]}" ]; then
       LOG_LEVEL=info
     else
@@ -128,6 +128,10 @@ function influxd::config::get()
     )
   }
 
+  #
+  # Parse Value from Arguments
+  #
+
   local primary_key="${1}" && shift
 
   # Command line arguments take precedence over all other configuration
@@ -142,6 +146,10 @@ function influxd::config::get()
     esac
   done
 
+  #
+  # Parse Value from Environment
+  #
+
   local value
   local default
 
@@ -150,34 +158,41 @@ function influxd::config::get()
   # it is possible that variable was intentionally emptied; therefore, this
   # returns nothing when empty.
   value="$(table::get "${primary_key}" ${COLUMN_ENVIRONMENT})"
-  if [[ "${!value+x}" ]] ; then
-    echo "${!value:-}" && return
+  if [[ ${!value+x} ]] ; then
+    echo "${!value}" && return
   fi
 
-  # Finally, search the configuration files. `yq` is required as the format
-  # could be json, toml, yaml, etc. If the corresponding value could not be
-  # located within the configuration files, provide the default value. This
-  # default is what `influx server-config` would display if recently
-  # initialized with `influx setup`.
-  default="$(table::get "${primary_key}" "${COLUMN_DEFAULT}")"
+  #
+  # Parse Value from Configuration
+  #
 
-  if [[ "${INFLUXD_CONFIG_PATH}" == *toml ]]
+  case ${INFLUXD_CONFIG_PATH,,} in
+    *.toml)       local influxd_config_format=toml ;;
+    *.json)       local influxd_config_format=json ;;
+    *.yaml|*.yml) local influxd_config_format=yaml ;;
+  esac
+
+  # Unfortunately, dasel does not provide a method to test for the existence
+  # of a particular key. However, it returns with an error if it attempts to
+  # delete a nonexistent key. Since dasel will automatically update the
+  # configuration file, it is passed via `STDIN` to avoid this behavior.
+  if dasel -r "${influxd_config_format}" delete "${primary_key}" <"${INFLUXD_CONFIG_PATH}" &>/dev/null
   then
-    # There are two yq projects. Unfortunately, only the python version can
-    # process toml documents and this is the go implementation. Downloading
-    # python libraries would increase the docker image size considerably.
-    # Fortunately, processing toml as props extracts most information.
-    value="$(yq -p props eval ".\"${primary_key}\" // \"${default}\"" "${INFLUXD_CONFIG_PATH}")"
+    # Unfortunately, dasel has inconsistent string displaying behavior. For
+    # yaml and toml, it will display the value without double-quotes unless
+    # the string is empty. However, for json, it always with double-quotes.
+    # This always strips the first leading and trailing double-quotes, as
+    # they are almost always not required.
+    value="$(dasel -f "${INFLUXD_CONFIG_PATH}" -s "${primary_key}")"
 
     ( # strip leading and trailing " characters
       shopt -s extglob
-
       value="${value#'"'}"
       value="${value%'"'}"
       echo "${value}"
     )
   else
-    yq eval ".\"${primary_key}\" // \"${default}\"" "${INFLUXD_CONFIG_PATH}"
+    table::get "${primary_key}" "${COLUMN_DEFAULT}"
   fi
 }
 
@@ -208,6 +223,7 @@ function create_directories () {
 # Read password and username from file to avoid unsecure env variables
 if [ -n "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}" ] && DOCKER_INFLUXDB_INIT_PASSWORD=$(cat "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}") || echo "DOCKER_INFLUXDB_INIT_PASSWORD_FILE defined, but file not existing, skipping."; fi
 if [ -n "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}" ] && DOCKER_INFLUXDB_INIT_USERNAME=$(cat "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}") || echo "DOCKER_INFLUXDB_INIT_USERNAME_FILE defined, but file not existing, skipping."; fi
+if [ -n "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}" ] && DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=$(cat "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}") || echo "DOCKER_INFLUXDB_INIT_USERNAME_FILE defined, but file not existing, skipping."; fi
 
 # List of env vars required to auto-run setup or upgrade processes.
 declare -ra REQUIRED_INIT_VARS=(
@@ -401,13 +417,24 @@ function init_influxd () {
       final_host_scheme="https"
     fi
 
+    case ${INFLUXD_CONFIG_PATH,,} in
+      *.toml)       local influxd_config_format=toml ;;
+      *.json)       local influxd_config_format=json ;;
+      *.yaml|*.yml) local influxd_config_format=yaml ;;
+    esac
+
     # Generate a config file with a known HTTP port, and TLS disabled.
     local -r init_config=/tmp/config.json
-    yq --tojson eval '
-      .http-bind-address = "'"${init_bind_addr}"'"
-        | del(.tls-cert)
-        | del(.tls-key)
-    ' ${INFLUXD_CONFIG_PATH} | tee "${init_config}"
+    (
+      dasel -r "${influxd_config_format}" -w json \
+        | dasel -r json put http-bind-address -v "${init_bind_addr}" \
+        `# insert "tls-cert" and "tls-key" so delete succeeds` \
+        | dasel -r json put tls-cert -v ''                     \
+        | dasel -r json put tls-key  -v ''                     \
+        `# delete "tls-cert" and "tls-key"` \
+        | dasel -r json delete tls-cert     \
+        | dasel -r json delete tls-key
+    ) <"${INFLUXD_CONFIG_PATH}" | tee "${init_config}"
 
     # Start influxd in the background.
     log info "booting influxd server in the background"
@@ -481,7 +508,7 @@ function main () {
     if [ -f "${BOLT_PATH}" ]; then
         log info "found existing boltdb file, skipping setup wrapper" bolt_path "${BOLT_PATH}"
     elif [ -z "${DOCKER_INFLUXDB_INIT_MODE}" ]; then
-        log warn "boltdb not found at configured path, but DOCKER_INFLUXDB_INIT_MODE not specified, skipping setup wrapper" bolt_path "${bolt_path}"
+        log warn "boltdb not found at configured path, but DOCKER_INFLUXDB_INIT_MODE not specified, skipping setup wrapper" bolt_path "${BOLT_PATH}"
     else
         init_influxd "${@}"
         # Set correct permission on volume directories again. This is necessary so that if the container was run as the
@@ -492,7 +519,6 @@ function main () {
 
     if [ "$(id -u)" = 0 ]; then
         exec su-exec influxdb "$BASH_SOURCE" "${@}"
-        return
     fi
 
     # Run influxd.


### PR DESCRIPTION
Unfortunately, it appeared that the `yq` hack didn't work with all scenarios. This replaces `jq` and `yq` with `dasel`. `dasel` can parse json, yaml, toml, xml and more. However, it has a few "rough edges" that the `jq` and `yq` implementation did not have. I'e broken this into two commits. The first commit contains changes in the `influxdb/2.4` directory. The second commit just copies the changes to most other `influxdb` directories.