### PR TITLE
Update Chronograf maintainers

### DIFF
--- a/chronograf/manifest.json
+++ b/chronograf/manifest.json
@@ -1,8 +1,6 @@
 {
   "name": "chronograf",
   "maintainers": [
-    "Jonathan A. Sternberg <jonathan@influxdata.com> (@jsternberg)",
-    "Bucky Schwarz <bucky@influxdata.com> (@hoorayimhelping)",
     "Brandon Pfeifer  <bpfeifer@influxdata.com> (@bnpfeife)"
   ],
   "versions": ["1.6", "1.7", "1.8", "1.9"],


### PR DESCRIPTION
Following the request from https://github.com/docker-library/official-images/pull/15604#issuecomment-1776086571.

I was under the impression that it needs updating here before the [`library/chrongraf`](https://github.com/docker-library/official-images/blob/c87e52a043d7cf303f0fdb7e8c033f3f7d841edf/library/chronograf#L1-L3) file in docker-library/official-images and then I assume the next PR to official-images will include the change.