### PR TITLE
feat: restrict capabilities for telegraf

### DIFF
--- a/telegraf/1.27/entrypoint.sh
+++ b/telegraf/1.27/entrypoint.sh
@@ -11,5 +11,5 @@ else
     # Allow telegraf to send ICMP packets and bind to privliged ports
     setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
 
-    exec setpriv --reuid telegraf --init-groups "$@"
+    exec setpriv --reuid telegraf --regid telegraf --reset-env --clear-groups "$@"
 fi

--- a/telegraf/1.27/entrypoint.sh
+++ b/telegraf/1.27/entrypoint.sh
@@ -11,5 +11,6 @@ else
     # Allow telegraf to send ICMP packets and bind to privliged ports
     setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
 
-    exec setpriv --reuid telegraf --regid telegraf --reset-env --clear-groups "$@"
+    export HOME=$(getent passwd telegraf | cut -d : -f 6)
+    exec setpriv --reuid telegraf --regid telegraf --groups telegraf "$@"
 fi

--- a/telegraf/1.27/entrypoint.sh
+++ b/telegraf/1.27/entrypoint.sh
@@ -8,9 +8,6 @@ fi
 if [ $EUID -ne 0 ]; then
     exec "$@"
 else
-    # Allow telegraf to send ICMP packets and bind to privliged ports
-    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
-
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
-    exec setpriv --reuid telegraf --regid telegraf --groups telegraf "$@"
+    exec setpriv --reuid telegraf --regid telegraf --groups telegraf --bounding-set=-all,+net_raw,+net_bind_service --inh-caps=-all,+net_raw,+net_bind_service "$@"
 fi

--- a/telegraf/1.28/entrypoint.sh
+++ b/telegraf/1.28/entrypoint.sh
@@ -11,5 +11,5 @@ else
     # Allow telegraf to send ICMP packets and bind to privliged ports
     setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
 
-    exec setpriv --reuid telegraf --init-groups "$@"
+    exec setpriv --reuid telegraf --regid telegraf --reset-env --clear-groups "$@"
 fi

--- a/telegraf/1.28/entrypoint.sh
+++ b/telegraf/1.28/entrypoint.sh
@@ -11,5 +11,6 @@ else
     # Allow telegraf to send ICMP packets and bind to privliged ports
     setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
 
-    exec setpriv --reuid telegraf --regid telegraf --reset-env --clear-groups "$@"
+    export HOME=$(getent passwd telegraf | cut -d : -f 6)
+    exec setpriv --reuid telegraf --regid telegraf --groups telegraf "$@"
 fi

--- a/telegraf/1.28/entrypoint.sh
+++ b/telegraf/1.28/entrypoint.sh
@@ -8,9 +8,6 @@ fi
 if [ $EUID -ne 0 ]; then
     exec "$@"
 else
-    # Allow telegraf to send ICMP packets and bind to privliged ports
-    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
-
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
-    exec setpriv --reuid telegraf --regid telegraf --groups telegraf "$@"
+    exec setpriv --reuid telegraf --regid telegraf --groups telegraf --bounding-set=-all,+net_raw,+net_bind_service --inh-caps=-all,+net_raw,+net_bind_service "$@"
 fi

--- a/telegraf/1.29/entrypoint.sh
+++ b/telegraf/1.29/entrypoint.sh
@@ -11,5 +11,5 @@ else
     # Allow telegraf to send ICMP packets and bind to privliged ports
     setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
 
-    exec setpriv --reuid telegraf --init-groups "$@"
+    exec setpriv --reuid telegraf --regid telegraf --reset-env --clear-groups "$@"
 fi

--- a/telegraf/1.29/entrypoint.sh
+++ b/telegraf/1.29/entrypoint.sh
@@ -11,5 +11,6 @@ else
     # Allow telegraf to send ICMP packets and bind to privliged ports
     setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
 
-    exec setpriv --reuid telegraf --regid telegraf --reset-env --clear-groups "$@"
+    export HOME=$(getent passwd telegraf | cut -d : -f 6)
+    exec setpriv --reuid telegraf --regid telegraf --groups telegraf "$@"
 fi

--- a/telegraf/1.29/entrypoint.sh
+++ b/telegraf/1.29/entrypoint.sh
@@ -8,9 +8,6 @@ fi
 if [ $EUID -ne 0 ]; then
     exec "$@"
 else
-    # Allow telegraf to send ICMP packets and bind to privliged ports
-    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
-
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
-    exec setpriv --reuid telegraf --regid telegraf --groups telegraf "$@"
+    exec setpriv --reuid telegraf --regid telegraf --groups telegraf --bounding-set=-all,+net_raw,+net_bind_service --inh-caps=-all,+net_raw,+net_bind_service "$@"
 fi

--- a/telegraf/nightly/entrypoint.sh
+++ b/telegraf/nightly/entrypoint.sh
@@ -11,5 +11,5 @@ else
     # Allow telegraf to send ICMP packets and bind to privliged ports
     setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
 
-    exec setpriv --reuid telegraf --init-groups "$@"
+    exec setpriv --reuid telegraf --regid telegraf --reset-env --clear-groups "$@"
 fi

--- a/telegraf/nightly/entrypoint.sh
+++ b/telegraf/nightly/entrypoint.sh
@@ -11,5 +11,6 @@ else
     # Allow telegraf to send ICMP packets and bind to privliged ports
     setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
 
-    exec setpriv --reuid telegraf --regid telegraf --reset-env --clear-groups "$@"
+    export HOME=$(getent passwd telegraf | cut -d : -f 6)
+    exec setpriv --reuid telegraf --regid telegraf --groups telegraf "$@"
 fi

--- a/telegraf/nightly/entrypoint.sh
+++ b/telegraf/nightly/entrypoint.sh
@@ -8,9 +8,6 @@ fi
 if [ $EUID -ne 0 ]; then
     exec "$@"
 else
-    # Allow telegraf to send ICMP packets and bind to privliged ports
-    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
-
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
-    exec setpriv --reuid telegraf --regid telegraf --groups telegraf "$@"
+    exec setpriv --reuid telegraf --regid telegraf --groups telegraf --bounding-set=-all,+net_raw,+net_bind_service --inh-caps=-all,+net_raw,+net_bind_service "$@"
 fi


### PR DESCRIPTION
TODO: need to check what happens if a capability fails to apply. This is why we previously have the or echo failed message.