### PR TITLE
telegraf: Switch from sed to for loop for parsing groups

### DIFF
--- a/telegraf/1.28/entrypoint.sh
+++ b/telegraf/1.28/entrypoint.sh
@@ -18,7 +18,7 @@ else
     # (also removes 'telegraf' since we unconditionally add it and don't want it listed twice)
     # see https://github.com/influxdata/influxdata-docker/issues/724
     groups="telegraf"
-    extra_groups="$(id -Gn)"
+    extra_groups="$(id -Gn || true)"
     for group in $extra_groups; do
         case "$group" in
             root | telegraf) ;;

--- a/telegraf/1.28/entrypoint.sh
+++ b/telegraf/1.28/entrypoint.sh
@@ -14,17 +14,16 @@ else
     # ensure HOME is set to the telegraf user's home dir
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
 
-    # honor groups supplied via 'docker run --group-add ...' but drop 'root' (the sed
-    # removes 'telegraf' since we unconditionally add it and don't want it listed twice)
+    # honor groups supplied via 'docker run --group-add ...' but drop 'root'
+    # (also removes 'telegraf' since we unconditionally add it and don't want it listed twice)
+    # see https://github.com/influxdata/influxdata-docker/issues/724
     groups="telegraf"
-    extra_groups="$(id -Gn | sed \
-    -e 's/ /,/g' \
-    -e 's/,\(root\|telegraf\),/,/g' \
-    -e 's/^\(root\|telegraf\),//g'  \
-    -e 's/,\(root\|telegraf\)$//g' \
-    -e 's/^\(root\|telegraf\)$//g')"
-    if [ -n "$extra_groups" ]; then
-        groups="$groups,$extra_groups"
-    fi
+    extra_groups="$(id -Gn)"
+    for group in $extra_groups; do
+        case "$group" in
+            root | telegraf) ;;
+            *) groups="$groups,$group" ;;
+        esac
+    done
     exec setpriv --reuid telegraf --regid telegraf --groups "$groups" "$@"
 fi

--- a/telegraf/1.29/entrypoint.sh
+++ b/telegraf/1.29/entrypoint.sh
@@ -18,7 +18,7 @@ else
     # (also removes 'telegraf' since we unconditionally add it and don't want it listed twice)
     # see https://github.com/influxdata/influxdata-docker/issues/724
     groups="telegraf"
-    extra_groups="$(id -Gn)"
+    extra_groups="$(id -Gn || true)"
     for group in $extra_groups; do
         case "$group" in
             root | telegraf) ;;

--- a/telegraf/1.29/entrypoint.sh
+++ b/telegraf/1.29/entrypoint.sh
@@ -14,17 +14,16 @@ else
     # ensure HOME is set to the telegraf user's home dir
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
 
-    # honor groups supplied via 'docker run --group-add ...' but drop 'root' (the sed
-    # removes 'telegraf' since we unconditionally add it and don't want it listed twice)
+    # honor groups supplied via 'docker run --group-add ...' but drop 'root'
+    # (also removes 'telegraf' since we unconditionally add it and don't want it listed twice)
+    # see https://github.com/influxdata/influxdata-docker/issues/724
     groups="telegraf"
-    extra_groups="$(id -Gn | sed \
-    -e 's/ /,/g' \
-    -e 's/,\(root\|telegraf\),/,/g' \
-    -e 's/^\(root\|telegraf\),//g'  \
-    -e 's/,\(root\|telegraf\)$//g' \
-    -e 's/^\(root\|telegraf\)$//g')"
-    if [ -n "$extra_groups" ]; then
-        groups="$groups,$extra_groups"
-    fi
+    extra_groups="$(id -Gn)"
+    for group in $extra_groups; do
+        case "$group" in
+            root | telegraf) ;;
+            *) groups="$groups,$group" ;;
+        esac
+    done
     exec setpriv --reuid telegraf --regid telegraf --groups "$groups" "$@"
 fi

--- a/telegraf/1.30/entrypoint.sh
+++ b/telegraf/1.30/entrypoint.sh
@@ -18,7 +18,7 @@ else
     # (also removes 'telegraf' since we unconditionally add it and don't want it listed twice)
     # see https://github.com/influxdata/influxdata-docker/issues/724
     groups="telegraf"
-    extra_groups="$(id -Gn)"
+    extra_groups="$(id -Gn || true)"
     for group in $extra_groups; do
         case "$group" in
             root | telegraf) ;;

--- a/telegraf/1.30/entrypoint.sh
+++ b/telegraf/1.30/entrypoint.sh
@@ -14,17 +14,16 @@ else
     # ensure HOME is set to the telegraf user's home dir
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
 
-    # honor groups supplied via 'docker run --group-add ...' but drop 'root' (the sed
-    # removes 'telegraf' since we unconditionally add it and don't want it listed twice)
+    # honor groups supplied via 'docker run --group-add ...' but drop 'root'
+    # (also removes 'telegraf' since we unconditionally add it and don't want it listed twice)
+    # see https://github.com/influxdata/influxdata-docker/issues/724
     groups="telegraf"
-    extra_groups="$(id -Gn | sed \
-    -e 's/ /,/g' \
-    -e 's/,\(root\|telegraf\),/,/g' \
-    -e 's/^\(root\|telegraf\),//g'  \
-    -e 's/,\(root\|telegraf\)$//g' \
-    -e 's/^\(root\|telegraf\)$//g')"
-    if [ -n "$extra_groups" ]; then
-        groups="$groups,$extra_groups"
-    fi
+    extra_groups="$(id -Gn)"
+    for group in $extra_groups; do
+        case "$group" in
+            root | telegraf) ;;
+            *) groups="$groups,$group" ;;
+        esac
+    done
     exec setpriv --reuid telegraf --regid telegraf --groups "$groups" "$@"
 fi

--- a/telegraf/nightly/entrypoint.sh
+++ b/telegraf/nightly/entrypoint.sh
@@ -18,7 +18,7 @@ else
     # (also removes 'telegraf' since we unconditionally add it and don't want it listed twice)
     # see https://github.com/influxdata/influxdata-docker/issues/724
     groups="telegraf"
-    extra_groups="$(id -Gn)"
+    extra_groups="$(id -Gn || true)"
     for group in $extra_groups; do
         case "$group" in
             root | telegraf) ;;

--- a/telegraf/nightly/entrypoint.sh
+++ b/telegraf/nightly/entrypoint.sh
@@ -14,17 +14,16 @@ else
     # ensure HOME is set to the telegraf user's home dir
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
 
-    # honor groups supplied via 'docker run --group-add ...' but drop 'root' (the sed
-    # removes 'telegraf' since we unconditionally add it and don't want it listed twice)
+    # honor groups supplied via 'docker run --group-add ...' but drop 'root'
+    # (also removes 'telegraf' since we unconditionally add it and don't want it listed twice)
+    # see https://github.com/influxdata/influxdata-docker/issues/724
     groups="telegraf"
-    extra_groups="$(id -Gn | sed \
-    -e 's/ /,/g' \
-    -e 's/,\(root\|telegraf\),/,/g' \
-    -e 's/^\(root\|telegraf\),//g'  \
-    -e 's/,\(root\|telegraf\)$//g' \
-    -e 's/^\(root\|telegraf\)$//g')"
-    if [ -n "$extra_groups" ]; then
-        groups="$groups,$extra_groups"
-    fi
+    extra_groups="$(id -Gn)"
+    for group in $extra_groups; do
+        case "$group" in
+            root | telegraf) ;;
+            *) groups="$groups,$group" ;;
+        esac
+    done
     exec setpriv --reuid telegraf --regid telegraf --groups "$groups" "$@"
 fi


### PR DESCRIPTION
Based on upstream suggestion in https://github.com/docker-library/official-images/pull/16387 switches the sed parsing to for loop.