### PR TITLE
fix: Remove unused and deprecated nats-port config

### DIFF
--- a/influxdb/2.2/alpine/default-config.yml
+++ b/influxdb/2.2/alpine/default-config.yml
@@ -1,3 +1,2 @@
 bolt-path: /var/lib/influxdb2/influxd.bolt
 engine-path: /var/lib/influxdb2/engine
-nats-port: 4222

--- a/influxdb/2.2/default-config.yml
+++ b/influxdb/2.2/default-config.yml
@@ -1,3 +1,2 @@
 bolt-path: /var/lib/influxdb2/influxd.bolt
 engine-path: /var/lib/influxdb2/engine
-nats-port: 4222

--- a/influxdb/2.3/alpine/default-config.yml
+++ b/influxdb/2.3/alpine/default-config.yml
@@ -1,3 +1,2 @@
 bolt-path: /var/lib/influxdb2/influxd.bolt
 engine-path: /var/lib/influxdb2/engine
-nats-port: 4222

--- a/influxdb/2.3/default-config.yml
+++ b/influxdb/2.3/default-config.yml
@@ -1,3 +1,2 @@
 bolt-path: /var/lib/influxdb2/influxd.bolt
 engine-path: /var/lib/influxdb2/engine
-nats-port: 4222

--- a/influxdb/2.4/alpine/default-config.yml
+++ b/influxdb/2.4/alpine/default-config.yml
@@ -1,3 +1,2 @@
 bolt-path: /var/lib/influxdb2/influxd.bolt
 engine-path: /var/lib/influxdb2/engine
-nats-port: 4222

--- a/influxdb/2.4/default-config.yml
+++ b/influxdb/2.4/default-config.yml
@@ -1,3 +1,2 @@
 bolt-path: /var/lib/influxdb2/influxd.bolt
 engine-path: /var/lib/influxdb2/engine
-nats-port: 4222

--- a/influxdb/2.5/alpine/default-config.yml
+++ b/influxdb/2.5/alpine/default-config.yml
@@ -1,3 +1,2 @@
 bolt-path: /var/lib/influxdb2/influxd.bolt
 engine-path: /var/lib/influxdb2/engine
-nats-port: 4222

--- a/influxdb/2.5/default-config.yml
+++ b/influxdb/2.5/default-config.yml
@@ -1,3 +1,2 @@
 bolt-path: /var/lib/influxdb2/influxd.bolt
 engine-path: /var/lib/influxdb2/engine
-nats-port: 4222

--- a/influxdb/2.6/alpine/default-config.yml
+++ b/influxdb/2.6/alpine/default-config.yml
@@ -1,3 +1,2 @@
 bolt-path: /var/lib/influxdb2/influxd.bolt
 engine-path: /var/lib/influxdb2/engine
-nats-port: 4222

--- a/influxdb/2.6/default-config.yml
+++ b/influxdb/2.6/default-config.yml
@@ -1,3 +1,2 @@
 bolt-path: /var/lib/influxdb2/influxd.bolt
 engine-path: /var/lib/influxdb2/engine
-nats-port: 4222

--- a/influxdb/2.7/alpine/default-config.yml
+++ b/influxdb/2.7/alpine/default-config.yml
@@ -1,3 +1,2 @@
 bolt-path: /var/lib/influxdb2/influxd.bolt
 engine-path: /var/lib/influxdb2/engine
-nats-port: 4222

--- a/influxdb/2.7/default-config.yml
+++ b/influxdb/2.7/default-config.yml
@@ -1,3 +1,2 @@
 bolt-path: /var/lib/influxdb2/influxd.bolt
 engine-path: /var/lib/influxdb2/engine
-nats-port: 4222


### PR DESCRIPTION
nats-port server configuration has been deprecated since 2.2 and its usage in default-config.yml is being warned for both deprecation and unusage.

**Warn snippet:** `lvl=warn msg="nats-port argument is deprecated and unused"`

**Full logs before fix (v2.4):**
```
bolt-path: /var/lib/influxdb2/influxd.bolt
engine-path: /var/lib/influxdb2/engine
nats-port: 4222
http-bind-address: :9999
2024-04-10T19:51:37.709177119Z  info    booting influxd server in the background        {"system": "docker"}
ts=2024-04-10T19:51:37.875343Z lvl=info msg="Welcome to InfluxDB" log_id=0oUOu0_l000 version=v2.4.0 commit=de247bab08 build_date=2022-08-18T19:41:15Z log_level=info
ts=2024-04-10T19:51:37.875409Z lvl=warn msg="nats-port argument is deprecated and unused" log_id=0oUOu0_l000
ts=2024-04-10T19:51:37.881090Z lvl=info msg="Resources opened" log_id=0oUOu0_l000 service=bolt path=/var/lib/influxdb2/influxd.bolt
ts=2024-04-10T19:51:37.881254Z lvl=info msg="Resources opened" log_id=0oUOu0_l000 service=sqlite path=/var/lib/influxdb2/influxd.sqlite
ts=2024-04-10T19:51:37.883592Z lvl=info msg="Bringing up metadata migrations" log_id=0oUOu0_l000 service="KV migrations" migration_count=20
ts=2024-04-10T19:51:38.051351Z lvl=info msg="Bringing up metadata migrations" log_id=0oUOu0_l000 service="SQL migrations" migration_count=7
ts=2024-04-10T19:51:38.086250Z lvl=info msg="Using data dir" log_id=0oUOu0_l000 service=storage-engine service=store path=/var/lib/influxdb2/engine/data
ts=2024-04-10T19:51:38.086386Z lvl=info msg="Compaction settings" log_id=0oUOu0_l000 service=storage-engine service=store max_concurrent_compactions=4 throughput_bytes_per_second=50331648 throughput_bytes_per_second_burst=50331648
ts=2024-04-10T19:51:38.086429Z lvl=info msg="Open store (start)" log_id=0oUOu0_l000 service=storage-engine service=store op_name=tsdb_open op_event=start
ts=2024-04-10T19:51:38.086580Z lvl=info msg="Open store (end)" log_id=0oUOu0_l000 service=storage-engine service=store op_name=tsdb_open op_event=end op_elapsed=0.152ms
ts=2024-04-10T19:51:38.086625Z lvl=info msg="Starting retention policy enforcement service" log_id=0oUOu0_l000 service=retention check_interval=30m
ts=2024-04-10T19:51:38.086646Z lvl=info msg="Starting precreation service" log_id=0oUOu0_l000 service=shard-precreation check_interval=10m advance_period=30m
ts=2024-04-10T19:51:38.087928Z lvl=info msg="Starting query controller" log_id=0oUOu0_l000 service=storage-reads concurrency_quota=1024 initial_memory_bytes_quota_per_query=9223372036854775807 memory_bytes_quota_per_query=9223372036854775807 max_memory_bytes=0 queue_size=1024
ts=2024-04-10T19:51:38.093879Z lvl=info msg="Configuring InfluxQL statement executor (zeros indicate unlimited)." log_id=0oUOu0_l000 max_select_point=0 max_select_series=0 max_select_buckets=0
ts=2024-04-10T19:51:38.105078Z lvl=info msg=Starting log_id=0oUOu0_l000 service=telemetry interval=8h
ts=2024-04-10T19:51:38.106750Z lvl=info msg=Listening log_id=0oUOu0_l000 service=tcp-listener transport=http addr=:9999 port=9999
2024-04-10T19:51:38.715296356Z  info    pinging influxd...      {"system": "docker", "ping_attempt": "0"}
2024-04-10T19:51:38.735467737Z  info    got response from influxd, proceeding   {"system": "docker", "total_pings": "1"}
User    Organization    Bucket
my-user my-org          my-bucket
2024-04-10T19:51:38.922322470Z  info    Executing user-provided scripts {"system": "docker", "script_dir": "/docker-entrypoint-initdb.d"}
2024-04-10T19:51:38.926772252Z  info    initialization complete, shutting down background influxd       {"system": "docker"}
2024-04-10T19:51:39.094735653Z  info    found existing boltdb file, skipping setup wrapper      {"system": "docker", "bolt_path": "/var/lib/influxdb2/influxd.bolt"}
ts=2024-04-10T19:51:39.307192Z lvl=info msg="Welcome to InfluxDB" log_id=0oUOu6AW000 version=v2.4.0 commit=de247bab08 build_date=2022-08-18T19:41:15Z log_level=info
ts=2024-04-10T19:51:39.307262Z lvl=warn msg="nats-port argument is deprecated and unused" log_id=0oUOu6AW000
ts=2024-04-10T19:51:39.309778Z lvl=info msg="Resources opened" log_id=0oUOu6AW000 service=bolt path=/var/lib/influxdb2/influxd.bolt
ts=2024-04-10T19:51:39.309877Z lvl=info msg="Resources opened" log_id=0oUOu6AW000 service=sqlite path=/var/lib/influxdb2/influxd.sqlite
ts=2024-04-10T19:51:39.316154Z lvl=info msg="Checking InfluxDB metadata for prior version." log_id=0oUOu6AW000 bolt_path=/var/lib/influxdb2/influxd.bolt
ts=2024-04-10T19:51:39.316407Z lvl=info msg="Using data dir" log_id=0oUOu6AW000 service=storage-engine service=store path=/var/lib/influxdb2/engine/data
ts=2024-04-10T19:51:39.316443Z lvl=info msg="Compaction settings" log_id=0oUOu6AW000 service=storage-engine service=store max_concurrent_compactions=4 throughput_bytes_per_second=50331648 throughput_bytes_per_second_burst=50331648
ts=2024-04-10T19:51:39.316454Z lvl=info msg="Open store (start)" log_id=0oUOu6AW000 service=storage-engine service=store op_name=tsdb_open op_event=start
ts=2024-04-10T19:51:39.316580Z lvl=info msg="Open store (end)" log_id=0oUOu6AW000 service=storage-engine service=store op_name=tsdb_open op_event=end op_elapsed=0.127ms
ts=2024-04-10T19:51:39.316619Z lvl=info msg="Starting retention policy enforcement service" log_id=0oUOu6AW000 service=retention check_interval=30m
ts=2024-04-10T19:51:39.316639Z lvl=info msg="Starting precreation service" log_id=0oUOu6AW000 service=shard-precreation check_interval=10m advance_period=30m
ts=2024-04-10T19:51:39.317825Z lvl=info msg="Starting query controller" log_id=0oUOu6AW000 service=storage-reads concurrency_quota=1024 initial_memory_bytes_quota_per_query=9223372036854775807 memory_bytes_quota_per_query=9223372036854775807 max_memory_bytes=0 queue_size=1024
ts=2024-04-10T19:51:39.322507Z lvl=info msg="Configuring InfluxQL statement executor (zeros indicate unlimited)." log_id=0oUOu6AW000 max_select_point=0 max_select_series=0 max_select_buckets=0
ts=2024-04-10T19:51:39.335347Z lvl=info msg=Starting log_id=0oUOu6AW000 service=telemetry interval=8h
ts=2024-04-10T19:51:39.335801Z lvl=info msg=Listening log_id=0oUOu6AW000 service=tcp-listener transport=http addr=:8086 port=8086
```
**Full logs after fix (v2.4):**
```
{
  "bolt-path": "/var/lib/influxdb2/influxd.bolt",
  "engine-path": "/var/lib/influxdb2/engine",
  "http-bind-address": ":9999"
}
2024-04-10T20:21:52.321081195Z  info    booting influxd server in the background        {"system": "docker"}
ts=2024-04-10T20:21:52.487057Z lvl=info msg="Welcome to InfluxDB" log_id=0oUQcluW000 version=v2.4.0 commit=de247bab08 build_date=2022-08-18T19:41:15Z log_level=info
ts=2024-04-10T20:21:52.501985Z lvl=info msg="Resources opened" log_id=0oUQcluW000 service=bolt path=/var/lib/influxdb2/influxd.bolt
ts=2024-04-10T20:21:52.502177Z lvl=info msg="Resources opened" log_id=0oUQcluW000 service=sqlite path=/var/lib/influxdb2/influxd.sqlite
ts=2024-04-10T20:21:52.504461Z lvl=info msg="Bringing up metadata migrations" log_id=0oUQcluW000 service="KV migrations" migration_count=20
ts=2024-04-10T20:21:52.674900Z lvl=info msg="Bringing up metadata migrations" log_id=0oUQcluW000 service="SQL migrations" migration_count=7
ts=2024-04-10T20:21:52.711868Z lvl=info msg="Using data dir" log_id=0oUQcluW000 service=storage-engine service=store path=/var/lib/influxdb2/engine/data
ts=2024-04-10T20:21:52.712032Z lvl=info msg="Compaction settings" log_id=0oUQcluW000 service=storage-engine service=store max_concurrent_compactions=4 throughput_bytes_per_second=50331648 throughput_bytes_per_second_burst=50331648
ts=2024-04-10T20:21:52.712050Z lvl=info msg="Open store (start)" log_id=0oUQcluW000 service=storage-engine service=store op_name=tsdb_open op_event=start
ts=2024-04-10T20:21:52.712203Z lvl=info msg="Open store (end)" log_id=0oUQcluW000 service=storage-engine service=store op_name=tsdb_open op_event=end op_elapsed=0.154ms
ts=2024-04-10T20:21:52.712281Z lvl=info msg="Starting retention policy enforcement service" log_id=0oUQcluW000 service=retention check_interval=30m
ts=2024-04-10T20:21:52.712301Z lvl=info msg="Starting precreation service" log_id=0oUQcluW000 service=shard-precreation check_interval=10m advance_period=30m
ts=2024-04-10T20:21:52.713521Z lvl=info msg="Starting query controller" log_id=0oUQcluW000 service=storage-reads concurrency_quota=1024 initial_memory_bytes_quota_per_query=9223372036854775807 memory_bytes_quota_per_query=9223372036854775807 max_memory_bytes=0 queue_size=1024
ts=2024-04-10T20:21:52.720341Z lvl=info msg="Configuring InfluxQL statement executor (zeros indicate unlimited)." log_id=0oUQcluW000 max_select_point=0 max_select_series=0 max_select_buckets=0
ts=2024-04-10T20:21:52.729673Z lvl=info msg=Starting log_id=0oUQcluW000 service=telemetry interval=8h
ts=2024-04-10T20:21:52.731381Z lvl=info msg=Listening log_id=0oUQcluW000 service=tcp-listener transport=http addr=:9999 port=9999
2024-04-10T20:21:53.327701883Z  info    pinging influxd...      {"system": "docker", "ping_attempt": "0"}
2024-04-10T20:21:53.348349669Z  info    got response from influxd, proceeding   {"system": "docker", "total_pings": "1"}
User    Organization    Bucket
my-user my-org          my-bucket
2024-04-10T20:21:53.561900088Z  info    Executing user-provided scripts {"system": "docker", "script_dir": "/docker-entrypoint-initdb.d"}
2024-04-10T20:21:53.565734846Z  info    initialization complete, shutting down background influxd       {"system": "docker"}
2024-04-10T20:21:53.728107763Z  info    found existing boltdb file, skipping setup wrapper      {"system": "docker", "bolt_path": "/var/lib/influxdb2/influxd.bolt"}
ts=2024-04-10T20:21:53.885047Z lvl=info msg="Welcome to InfluxDB" log_id=0oUQcrN0000 version=v2.4.0 commit=de247bab08 build_date=2022-08-18T19:41:15Z log_level=info
ts=2024-04-10T20:21:53.898179Z lvl=info msg="Resources opened" log_id=0oUQcrN0000 service=bolt path=/var/lib/influxdb2/influxd.bolt
ts=2024-04-10T20:21:53.898600Z lvl=info msg="Resources opened" log_id=0oUQcrN0000 service=sqlite path=/var/lib/influxdb2/influxd.sqlite
ts=2024-04-10T20:21:53.906435Z lvl=info msg="Checking InfluxDB metadata for prior version." log_id=0oUQcrN0000 bolt_path=/var/lib/influxdb2/influxd.bolt
ts=2024-04-10T20:21:53.906712Z lvl=info msg="Using data dir" log_id=0oUQcrN0000 service=storage-engine service=store path=/var/lib/influxdb2/engine/data
ts=2024-04-10T20:21:53.906765Z lvl=info msg="Compaction settings" log_id=0oUQcrN0000 service=storage-engine service=store max_concurrent_compactions=4 throughput_bytes_per_second=50331648 throughput_bytes_per_second_burst=50331648
ts=2024-04-10T20:21:53.906783Z lvl=info msg="Open store (start)" log_id=0oUQcrN0000 service=storage-engine service=store op_name=tsdb_open op_event=start
ts=2024-04-10T20:21:53.906920Z lvl=info msg="Open store (end)" log_id=0oUQcrN0000 service=storage-engine service=store op_name=tsdb_open op_event=end op_elapsed=0.138ms
ts=2024-04-10T20:21:53.906966Z lvl=info msg="Starting retention policy enforcement service" log_id=0oUQcrN0000 service=retention check_interval=30m
ts=2024-04-10T20:21:53.906995Z lvl=info msg="Starting precreation service" log_id=0oUQcrN0000 service=shard-precreation check_interval=10m advance_period=30m
ts=2024-04-10T20:21:53.908290Z lvl=info msg="Starting query controller" log_id=0oUQcrN0000 service=storage-reads concurrency_quota=1024 initial_memory_bytes_quota_per_query=9223372036854775807 memory_bytes_quota_per_query=9223372036854775807 max_memory_bytes=0 queue_size=1024
ts=2024-04-10T20:21:53.914075Z lvl=info msg="Configuring InfluxQL statement executor (zeros indicate unlimited)." log_id=0oUQcrN0000 max_select_point=0 max_select_series=0 max_select_buckets=0
ts=2024-04-10T20:21:53.926736Z lvl=info msg=Starting log_id=0oUQcrN0000 service=telemetry interval=8h
ts=2024-04-10T20:21:53.927084Z lvl=info msg=Listening log_id=0oUQcrN0000 service=tcp-listener transport=http addr=:8086 port=8086
```