### PR TITLE
style: Improve logging similarity to InfluxDB 

### DIFF
--- a/influxdb/2.7/entrypoint.sh
+++ b/influxdb/2.7/entrypoint.sh
@@ -46,14 +46,14 @@ function log () {
         return
     fi
 
-    local attrs='"system": "docker"'
+    local attrs="system=docker"
     while [ "$#" -gt 1 ]; do
-        attrs="${attrs}, \"$1\": \"$2\""
+        attrs="${attrs} $1: $2"
         shift 2
     done
 
     local -r logtime="$(date --utc +'%FT%T.%NZ')"
-    1>&2 echo -e "${logtime}\t${level}\t${msg}\t{${attrs}}"
+    1>&2 echo -e "ts=${logtime} lvl=${level} msg=\"${msg}\" ${attrs}"
 }
 
 # Set the global log-level for the entry-point to match the config passed to influxd.

--- a/influxdb/2.7/entrypoint.sh
+++ b/influxdb/2.7/entrypoint.sh
@@ -52,7 +52,7 @@ function log () {
         shift 2
     done
 
-    local -r logtime="$(date --utc +'%FT%T.%NZ')"
+    local -r logtime=$(date --utc +%FT%T.%6NZ)
     1>&2 echo -e "ts=${logtime} lvl=${level} msg=\"${msg}\" ${attrs}"
 }
 


### PR DESCRIPTION
This PR improves the similarity between the logging generated by entrypoint.sh and the ones generated by InfluxDB.

**Before:**
```
{
  "bolt-path": "/var/lib/influxdb2/influxd.bolt",
  "engine-path": "/var/lib/influxdb2/engine",
  "nats-port": 4222,
  "http-bind-address": ":9999"
}
2024-04-10T20:40:03.765223531Z  info    booting influxd server in the background        {"system": "docker"}
ts=2024-04-10T20:40:03.920333Z lvl=info msg="Welcome to InfluxDB" log_id=0oURfOK0000 version=v2.7.5 commit=09a9607fd9 build_date=2024-01-05T17:17:04Z log_level=info
ts=2024-04-10T20:40:03.920447Z lvl=warn msg="nats-port argument is deprecated and unused" log_id=0oURfOK0000
ts=2024-04-10T20:40:03.926428Z lvl=info msg="Resources opened" log_id=0oURfOK0000 service=bolt path=/var/lib/influxdb2/influxd.bolt
ts=2024-04-10T20:40:03.926613Z lvl=info msg="Resources opened" log_id=0oURfOK0000 service=sqlite path=/var/lib/influxdb2/influxd.sqlite
ts=2024-04-10T20:40:03.928718Z lvl=info msg="Bringing up metadata migrations" log_id=0oURfOK0000 service="KV migrations" migration_count=20
ts=2024-04-10T20:40:04.097092Z lvl=info msg="Bringing up metadata migrations" log_id=0oURfOK0000 service="SQL migrations" migration_count=8
ts=2024-04-10T20:40:04.150986Z lvl=info msg="Using data dir" log_id=0oURfOK0000 service=storage-engine service=store path=/var/lib/influxdb2/engine/data
ts=2024-04-10T20:40:04.151121Z lvl=info msg="Compaction settings" log_id=0oURfOK0000 service=storage-engine service=store max_concurrent_compactions=4 throughput_bytes_per_second=50331648 throughput_bytes_per_second_burst=50331648
ts=2024-04-10T20:40:04.151135Z lvl=info msg="Open store (start)" log_id=0oURfOK0000 service=storage-engine service=store op_name=tsdb_open op_event=start
ts=2024-04-10T20:40:04.151213Z lvl=info msg="Open store (end)" log_id=0oURfOK0000 service=storage-engine service=store op_name=tsdb_open op_event=end op_elapsed=0.079ms
ts=2024-04-10T20:40:04.151258Z lvl=info msg="Starting retention policy enforcement service" log_id=0oURfOK0000 service=retention check_interval=30m
ts=2024-04-10T20:40:04.151271Z lvl=info msg="Starting precreation service" log_id=0oURfOK0000 service=shard-precreation check_interval=10m advance_period=30m
ts=2024-04-10T20:40:04.152403Z lvl=info msg="Starting query controller" log_id=0oURfOK0000 service=storage-reads concurrency_quota=1024 initial_memory_bytes_quota_per_query=9223372036854775807 memory_bytes_quota_per_query=9223372036854775807 max_memory_bytes=0 queue_size=1024
ts=2024-04-10T20:40:04.157659Z lvl=info msg="Configuring InfluxQL statement executor (zeros indicate unlimited)." log_id=0oURfOK0000 max_select_point=0 max_select_series=0 max_select_buckets=0
ts=2024-04-10T20:40:04.168614Z lvl=info msg=Starting log_id=0oURfOK0000 service=telemetry interval=8h
ts=2024-04-10T20:40:04.170203Z lvl=info msg=Listening log_id=0oURfOK0000 service=tcp-listener transport=http addr=:9999 port=9999
2024-04-10T20:40:04.771429738Z  info    pinging influxd...      {"system": "docker", "ping_attempt": "0"}
2024-04-10T20:40:04.792445416Z  info    got response from influxd, proceeding   {"system": "docker", "total_pings": "1"}
User    Organization    Bucket
my-user my-org          my-bucket
2024-04-10T20:40:05.002698964Z  info    Executing user-provided scripts {"system": "docker", "script_dir": "/docker-entrypoint-initdb.d"}
2024-04-10T20:40:05.006254837Z  info    initialization complete, shutting down background influxd       {"system": "docker"}
2024-04-10T20:40:05.224753410Z  info    found existing boltdb file, skipping setup wrapper      {"system": "docker", "bolt_path": "/var/lib/influxdb2/influxd.bolt"}
ts=2024-04-10T20:40:05.399201Z lvl=info msg="Welcome to InfluxDB" log_id=0oURfU5W000 version=v2.7.5 commit=09a9607fd9 build_date=2024-01-05T17:17:04Z log_level=info
ts=2024-04-10T20:40:05.399309Z lvl=warn msg="nats-port argument is deprecated and unused" log_id=0oURfU5W000
ts=2024-04-10T20:40:05.412328Z lvl=info msg="Resources opened" log_id=0oURfU5W000 service=bolt path=/var/lib/influxdb2/influxd.bolt
ts=2024-04-10T20:40:05.412566Z lvl=info msg="Resources opened" log_id=0oURfU5W000 service=sqlite path=/var/lib/influxdb2/influxd.sqlite
ts=2024-04-10T20:40:05.419410Z lvl=info msg="Checking InfluxDB metadata for prior version." log_id=0oURfU5W000 bolt_path=/var/lib/influxdb2/influxd.bolt
ts=2024-04-10T20:40:05.419608Z lvl=info msg="Using data dir" log_id=0oURfU5W000 service=storage-engine service=store path=/var/lib/influxdb2/engine/data
ts=2024-04-10T20:40:05.419689Z lvl=info msg="Compaction settings" log_id=0oURfU5W000 service=storage-engine service=store max_concurrent_compactions=4 throughput_bytes_per_second=50331648 throughput_bytes_per_second_burst=50331648
ts=2024-04-10T20:40:05.419719Z lvl=info msg="Open store (start)" log_id=0oURfU5W000 service=storage-engine service=store op_name=tsdb_open op_event=start
ts=2024-04-10T20:40:05.419841Z lvl=info msg="Open store (end)" log_id=0oURfU5W000 service=storage-engine service=store op_name=tsdb_open op_event=end op_elapsed=0.133ms
ts=2024-04-10T20:40:05.419875Z lvl=info msg="Starting retention policy enforcement service" log_id=0oURfU5W000 service=retention check_interval=30m
ts=2024-04-10T20:40:05.419894Z lvl=info msg="Starting precreation service" log_id=0oURfU5W000 service=shard-precreation check_interval=10m advance_period=30m
ts=2024-04-10T20:40:05.421215Z lvl=info msg="Starting query controller" log_id=0oURfU5W000 service=storage-reads concurrency_quota=1024 initial_memory_bytes_quota_per_query=9223372036854775807 memory_bytes_quota_per_query=9223372036854775807 max_memory_bytes=0 queue_size=1024
ts=2024-04-10T20:40:05.426389Z lvl=info msg="Configuring InfluxQL statement executor (zeros indicate unlimited)." log_id=0oURfU5W000 max_select_point=0 max_select_series=0 max_select_buckets=0
ts=2024-04-10T20:40:05.437575Z lvl=info msg=Starting log_id=0oURfU5W000 service=telemetry interval=8h
ts=2024-04-10T20:40:05.437915Z lvl=info msg=Listening log_id=0oURfU5W000 service=tcp-listener transport=http addr=:8086 port=8086
```
**After:**
```
{
  "bolt-path": "/var/lib/influxdb2/influxd.bolt",
  "engine-path": "/var/lib/influxdb2/engine",
  "nats-port": 4222,
  "http-bind-address": ":9999"
}
ts=2024-04-10T21:39:25.044272Z lvl=info msg="booting influxd server in the background" system=docker
ts=2024-04-10T21:39:25.223971Z lvl=info msg="Welcome to InfluxDB" log_id=0oUV3kel000 version=v2.7.5 commit=09a9607fd9 build_date=2024-01-05T17:17:04Z log_level=info
ts=2024-04-10T21:39:25.224054Z lvl=warn msg="nats-port argument is deprecated and unused" log_id=0oUV3kel000
ts=2024-04-10T21:39:25.239144Z lvl=info msg="Resources opened" log_id=0oUV3kel000 service=bolt path=/var/lib/influxdb2/influxd.bolt
ts=2024-04-10T21:39:25.239384Z lvl=info msg="Resources opened" log_id=0oUV3kel000 service=sqlite path=/var/lib/influxdb2/influxd.sqlite
ts=2024-04-10T21:39:25.241770Z lvl=info msg="Bringing up metadata migrations" log_id=0oUV3kel000 service="KV migrations" migration_count=20
ts=2024-04-10T21:39:25.419091Z lvl=info msg="Bringing up metadata migrations" log_id=0oUV3kel000 service="SQL migrations" migration_count=8
ts=2024-04-10T21:39:25.484548Z lvl=info msg="Using data dir" log_id=0oUV3kel000 service=storage-engine service=store path=/var/lib/influxdb2/engine/data
ts=2024-04-10T21:39:25.484700Z lvl=info msg="Compaction settings" log_id=0oUV3kel000 service=storage-engine service=store max_concurrent_compactions=4 throughput_bytes_per_second=50331648 throughput_bytes_per_second_burst=50331648
ts=2024-04-10T21:39:25.484720Z lvl=info msg="Open store (start)" log_id=0oUV3kel000 service=storage-engine service=store op_name=tsdb_open op_event=start
ts=2024-04-10T21:39:25.484889Z lvl=info msg="Open store (end)" log_id=0oUV3kel000 service=storage-engine service=store op_name=tsdb_open op_event=end op_elapsed=0.173ms
ts=2024-04-10T21:39:25.484943Z lvl=info msg="Starting retention policy enforcement service" log_id=0oUV3kel000 service=retention check_interval=30m
ts=2024-04-10T21:39:25.484969Z lvl=info msg="Starting precreation service" log_id=0oUV3kel000 service=shard-precreation check_interval=10m advance_period=30m
ts=2024-04-10T21:39:25.486451Z lvl=info msg="Starting query controller" log_id=0oUV3kel000 service=storage-reads concurrency_quota=1024 initial_memory_bytes_quota_per_query=9223372036854775807 memory_bytes_quota_per_query=9223372036854775807 max_memory_bytes=0 queue_size=1024
ts=2024-04-10T21:39:25.491400Z lvl=info msg="Configuring InfluxQL statement executor (zeros indicate unlimited)." log_id=0oUV3kel000 max_select_point=0 max_select_series=0 max_select_buckets=0
ts=2024-04-10T21:39:25.502667Z lvl=info msg=Starting log_id=0oUV3kel000 service=telemetry interval=8h
ts=2024-04-10T21:39:25.504488Z lvl=info msg=Listening log_id=0oUV3kel000 service=tcp-listener transport=http addr=:9999 port=9999
ts=2024-04-10T21:39:26.050729Z lvl=info msg="pinging influxd..." system=docker ping_attempt: 0
ts=2024-04-10T21:39:26.070615Z lvl=info msg="got response from influxd, proceeding" system=docker total_pings: 1
User    Organization    Bucket
my-user my-org          my-bucket
ts=2024-04-10T21:39:26.278675Z lvl=info msg="Executing user-provided scripts" system=docker script_dir: /docker-entrypoint-initdb.d
ts=2024-04-10T21:39:26.283563Z lvl=info msg="initialization complete, shutting down background influxd" system=docker
ts=2024-04-10T21:39:26.474993Z lvl=info msg="found existing boltdb file, skipping setup wrapper" system=docker bolt_path: /var/lib/influxdb2/influxd.bolt
ts=2024-04-10T21:39:26.649690Z lvl=info msg="Welcome to InfluxDB" log_id=0oUV3qEG000 version=v2.7.5 commit=09a9607fd9 build_date=2024-01-05T17:17:04Z log_level=info
ts=2024-04-10T21:39:26.649748Z lvl=warn msg="nats-port argument is deprecated and unused" log_id=0oUV3qEG000
ts=2024-04-10T21:39:26.662702Z lvl=info msg="Resources opened" log_id=0oUV3qEG000 service=bolt path=/var/lib/influxdb2/influxd.bolt
ts=2024-04-10T21:39:26.663047Z lvl=info msg="Resources opened" log_id=0oUV3qEG000 service=sqlite path=/var/lib/influxdb2/influxd.sqlite
ts=2024-04-10T21:39:26.670480Z lvl=info msg="Checking InfluxDB metadata for prior version." log_id=0oUV3qEG000 bolt_path=/var/lib/influxdb2/influxd.bolt
ts=2024-04-10T21:39:26.670653Z lvl=info msg="Using data dir" log_id=0oUV3qEG000 service=storage-engine service=store path=/var/lib/influxdb2/engine/data
ts=2024-04-10T21:39:26.670710Z lvl=info msg="Compaction settings" log_id=0oUV3qEG000 service=storage-engine service=store max_concurrent_compactions=4 throughput_bytes_per_second=50331648 throughput_bytes_per_second_burst=50331648
ts=2024-04-10T21:39:26.670721Z lvl=info msg="Open store (start)" log_id=0oUV3qEG000 service=storage-engine service=store op_name=tsdb_open op_event=start
ts=2024-04-10T21:39:26.670818Z lvl=info msg="Open store (end)" log_id=0oUV3qEG000 service=storage-engine service=store op_name=tsdb_open op_event=end op_elapsed=0.099ms
ts=2024-04-10T21:39:26.670855Z lvl=info msg="Starting retention policy enforcement service" log_id=0oUV3qEG000 service=retention check_interval=30m
ts=2024-04-10T21:39:26.670869Z lvl=info msg="Starting precreation service" log_id=0oUV3qEG000 service=shard-precreation check_interval=10m advance_period=30m
ts=2024-04-10T21:39:26.672197Z lvl=info msg="Starting query controller" log_id=0oUV3qEG000 service=storage-reads concurrency_quota=1024 initial_memory_bytes_quota_per_query=9223372036854775807 memory_bytes_quota_per_query=9223372036854775807 max_memory_bytes=0 queue_size=1024
ts=2024-04-10T21:39:26.677696Z lvl=info msg="Configuring InfluxQL statement executor (zeros indicate unlimited)." log_id=0oUV3qEG000 max_select_point=0 max_select_series=0 max_select_buckets=0
ts=2024-04-10T21:39:26.696437Z lvl=info msg=Starting log_id=0oUV3qEG000 service=telemetry interval=8h
ts=2024-04-10T21:39:26.697523Z lvl=info msg=Listening log_id=0oUV3qEG000 service=tcp-listener transport=http addr=:8086 port=8086
```