### PR TITLE
feat: allow running kapacitor as non-root

### DIFF
--- a/kapacitor/1.7/alpine/Dockerfile
+++ b/kapacitor/1.7/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.18
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache ca-certificates && \
+RUN apk add --no-cache ca-certificates su-exec && \
     update-ca-certificates
 
 ENV KAPACITOR_VERSION 1.7.3
@@ -23,8 +23,14 @@ RUN set -ex && \
     cp -ar /usr/src/kapacitor-*/* / && \
     gpgconf --kill all && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \
-    apk del .build-deps
+    apk del .build-deps && \
+    addgroup -S kapacitor && \
+    adduser -S kapacitor -G kapacitor && \
+    mkdir -m 0750 -p /var/lib/kapacitor && \
+    chown kapacitor:kapacitor /var/lib/kapacitor
+
 COPY kapacitor.conf /etc/kapacitor/kapacitor.conf
+
 EXPOSE 9092
 
 VOLUME /var/lib/kapacitor

--- a/kapacitor/1.7/alpine/entrypoint.sh
+++ b/kapacitor/1.7/alpine/entrypoint.sh
@@ -8,4 +8,8 @@ fi
 KAPACITOR_HOSTNAME=${KAPACITOR_HOSTNAME:-$HOSTNAME}
 export KAPACITOR_HOSTNAME
 
-exec "$@"
+if [ "$(id -u)" -ne 0 ] || [ "${KAPACITOR_AS_ROOT}" = "true" ]; then
+    exec "$@"
+else
+    exec su-exec kapacitor "$@"
+fi

--- a/kapacitor/1.7/entrypoint.sh
+++ b/kapacitor/1.7/entrypoint.sh
@@ -8,4 +8,8 @@ fi
 KAPACITOR_HOSTNAME=${KAPACITOR_HOSTNAME:-$HOSTNAME}
 export KAPACITOR_HOSTNAME
 
-exec "$@"
+if [ "$(id -u)" -ne 0 ] || [ "${KAPACITOR_AS_ROOT}" = "true" ]; then
+    exec "$@"
+else
+    exec setpriv --reuid kapacitor --regid kapacitor --init-groups "$@"
+fi


### PR DESCRIPTION
Closes https://github.com/influxdata/edge/issues/598

Same solution as in #731 , with opt-out for running as root with env var `KAPACITOR_AS_ROOT=true`.

Kapacitor does not require access to protected/system resources that might be limited when running as non-root. Inputs & outputs are done via http/TCP/UDP/filesystem. The documentation does not mention requiring any special permission. Non-docker installation from package runs as `kapacitord` as `kapacitor` user, and `kapacitord` does not have suid set.

Tested:
- [x] Uid, Gid in `/proc/1/status` for ubuntu & alpine image (1 = `kapacitord` PID) as in #731
- [x] integration
  - [x] InfluxDB 1.8 + Kapacitor + Chronograf + Telegraf
  - [x] alert rule definition and handler output
  - [x] custom tickscript with topic check