### PR TITLE
chore: Update Alpine images to 3.20

### DIFF
--- a/chronograf/1.10/alpine/Dockerfile
+++ b/chronograf/1.10/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.20
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates su-exec && \

--- a/chronograf/1.7/alpine/Dockerfile
+++ b/chronograf/1.7/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.20
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/chronograf/1.8/alpine/Dockerfile
+++ b/chronograf/1.8/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.20
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/chronograf/1.9/alpine/Dockerfile
+++ b/chronograf/1.9/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.20
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/influxdb/1.10/meta/alpine/Dockerfile
+++ b/influxdb/1.10/meta/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.20
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/1.11/meta/alpine/Dockerfile
+++ b/influxdb/1.11/meta/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.20
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/1.8/meta/alpine/Dockerfile
+++ b/influxdb/1.8/meta/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.20
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/1.9/meta/alpine/Dockerfile
+++ b/influxdb/1.9/meta/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.20
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/2.7/alpine/Dockerfile
+++ b/influxdb/2.7/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.20
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache \

--- a/kapacitor/1.6/alpine/Dockerfile
+++ b/kapacitor/1.6/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.20
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/kapacitor/1.7/alpine/Dockerfile
+++ b/kapacitor/1.7/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.20
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates su-exec && \

--- a/telegraf/1.28/alpine/Dockerfile
+++ b/telegraf/1.28/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.20
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata su-exec libcap && \

--- a/telegraf/1.29/alpine/Dockerfile
+++ b/telegraf/1.29/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.20
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata su-exec libcap && \

--- a/telegraf/1.30/alpine/Dockerfile
+++ b/telegraf/1.30/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.20
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata su-exec libcap && \


### PR DESCRIPTION
Per upstream Docker, they would prefer we stay with a specific minor release to avoid breaking changes. Instead of updating as soon as a new Alpine image is out, they would rather we specifically choose to update due to past experiences.

See https://github.com/docker-library/official-images/pull/16888