### PR TITLE
chore: update core and enterprise to 3.0.2

### DIFF
--- a/influxdb/3.0-core/Dockerfile
+++ b/influxdb/3.0-core/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.0.1
+ENV INFLUXDB_VERSION=3.0.2
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \

--- a/influxdb/3.0-enterprise/Dockerfile
+++ b/influxdb/3.0-enterprise/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.0.1
+ENV INFLUXDB_VERSION=3.0.2
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \


### PR DESCRIPTION
I tested this locally by building the images, and starting them to check that they report the correct version.

### Steps

Build the docker image:
```
cd influxdb/3.0-core
docker build -t "influxdb:core" .
```
Run the server with port `8181` exposed:
```
docker run -p 8181:8181 influxdb:core --node-id test --object-store memory --without-auth
```
Ping the server:
```
curl localhost:8181/ping
```
Gets the response:
```json
{"version":"3.0.2","revision":"d80d6cd600","process_id":"c3810409-51b6-4912-93f5-b663e399f2f3"}
```

Performed similar steps for Enterprise.