### PR TITLE
chore: add new dockerfile dedicated to core/ent 3.1.0

### DIFF
--- a/influxdb/3.0-core/Dockerfile
+++ b/influxdb/3.0-core/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.1.0
+ENV INFLUXDB_VERSION=3.0.3
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \

--- a/influxdb/3.1-core/Dockerfile
+++ b/influxdb/3.1-core/Dockerfile
@@ -16,29 +16,29 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.0.3
+ENV INFLUXDB_VERSION=3.1.0
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \
         *) echo 'Unsupported Architecture' ; exit 1 ;; \
     esac && \
-    curl -fsSLO "https://dl.influxdata.com/influxdb/releases/influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
-         -fsSLO "https://dl.influxdata.com/influxdb/releases/influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \
-    # Verify InfluxDB3 Enterprise \
+    curl -fsSLO "https://dl.influxdata.com/influxdb/releases/influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
+         -fsSLO "https://dl.influxdata.com/influxdb/releases/influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \
+    # Verify InfluxDB3 Core \
     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
         # InfluxData Package Signing Key <support@influxdata.com> \
         9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E && \
     gpg --batch --verify \
-        "influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
-        "influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \
-    # Install InfluxDB3 Enterprise \
-    tar --strip-components 1 -C /usr/lib/influxdb3 -xvf "influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \
+        "influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
+        "influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \
+    # Install InfluxDB3 Core \
+    tar --strip-components 1 -C /usr/lib/influxdb3 -xvf "influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \
     mv /usr/lib/influxdb3/influxdb3 /usr/bin/influxdb3 && \
     chown -R influxdb3:influxdb3 /var/lib/influxdb3 /plugins && \
     chown -R root:root /usr/lib/influxdb3 && \
     # Cleanup \
-    rm  "influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
-        "influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz"
+    rm  "influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
+        "influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz"
 
 COPY entrypoint.sh /usr/bin/entrypoint.sh
 

--- a/influxdb/3.1-core/entrypoint.sh
+++ b/influxdb/3.1-core/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+args=("${@}")
+
+if [[ "${args[0]:-}" == serve ]] ; then
+    args=(influxdb3 "${args[@]}")
+fi
+
+if [[ "${args[0]:-}" =~ ^- ]] ; then
+    args=(influxdb3 serve "${args[@]}")
+fi
+
+if [[ "${args[0]:-}" == influxdb3 ]] ; then
+    for i in "${!args[@]}"; do
+        args[i]="$(envsubst <<<"${args[i]}")"
+    done
+fi
+
+exec "${args[@]}"

--- a/influxdb/3.1-enterprise/Dockerfile
+++ b/influxdb/3.1-enterprise/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.0.3
+ENV INFLUXDB_VERSION=3.1.0
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \

--- a/influxdb/3.1-enterprise/entrypoint.sh
+++ b/influxdb/3.1-enterprise/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+args=("${@}")
+
+if [[ "${args[0]:-}" == serve ]] ; then
+    args=(influxdb3 "${args[@]}")
+fi
+
+if [[ "${args[0]:-}" =~ ^- ]] ; then
+    args=(influxdb3 serve "${args[@]}")
+fi
+
+if [[ "${args[0]:-}" == influxdb3 ]] ; then
+    for i in "${!args[@]}"; do
+        args[i]="$(envsubst <<<"${args[i]}")"
+    done
+fi
+
+exec "${args[@]}"


### PR DESCRIPTION
* Updates the versions for `3.0-core` and `3.0-enterprise` to use the latest `3.0.x` version: `3.0.3`.
* Adds `3.1-core/` and `3.1-enterprise/` to hold `Dockerfile` and `entrypoint.sh` (which were copied from the respective `3.0-` folder) and sets the version therein to `3.1.0`.