### PR TITLE
chore: create 3.2.0 release artefacts

### DIFF
--- a/influxdb/3.2-core/Dockerfile
+++ b/influxdb/3.2-core/Dockerfile
@@ -1,0 +1,56 @@
+FROM ubuntu:24.04
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y \
+        ca-certificates \
+        curl \
+        gettext-base \
+        gnupg \
+        libssl3 && \
+    rm -rf /var/lib/apt/lists*
+
+RUN groupadd --gid 1500 influxdb3 && \
+    useradd  --uid 1500 --gid influxdb3 --shell /bin/bash --create-home influxdb3 && \
+    mkdir -p /var/lib/influxdb3 \
+             /usr/lib/influxdb3 \
+             /plugins
+
+ENV INFLUXDB_VERSION=3.2.0
+RUN case "$(dpkg --print-architecture)" in \
+        amd64) ARCH=amd64 ;; \
+        arm64) ARCH=arm64 ;; \
+        *) echo 'Unsupported Architecture' ; exit 1 ;; \
+    esac && \
+    curl -fsSLO "https://dl.influxdata.com/influxdb/releases/influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
+         -fsSLO "https://dl.influxdata.com/influxdb/releases/influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \
+    # Verify InfluxDB3 Core \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
+        # InfluxData Package Signing Key <support@influxdata.com> \
+        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E && \
+    gpg --batch --verify \
+        "influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
+        "influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \
+    # Install InfluxDB3 Core \
+    tar --strip-components 1 -C /usr/lib/influxdb3 -xvf "influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \
+    mv /usr/lib/influxdb3/influxdb3 /usr/bin/influxdb3 && \
+    chown -R influxdb3:influxdb3 /var/lib/influxdb3 /plugins && \
+    chown -R root:root /usr/lib/influxdb3 && \
+    # Cleanup \
+    rm  "influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
+        "influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz"
+
+COPY entrypoint.sh /usr/bin/entrypoint.sh
+
+USER influxdb3
+RUN mkdir ~/.influxdb3
+
+ENV INFLUXDB3_PLUGIN_DIR=/plugins
+ENV INFLUXDB3_DATA_DIR=/home/influxdb3/.influxdb3
+ENV INFLUXDB_IOX_DB_DIR=/var/lib/influxdb3
+ENV LOG_FILTER=info
+
+EXPOSE 8181
+
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]
+CMD ["influxdb3", "serve"]

--- a/influxdb/3.2-core/entrypoint.sh
+++ b/influxdb/3.2-core/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+args=("${@}")
+
+if [[ "${args[0]:-}" == serve ]] ; then
+    args=(influxdb3 "${args[@]}")
+fi
+
+if [[ "${args[0]:-}" =~ ^- ]] ; then
+    args=(influxdb3 serve "${args[@]}")
+fi
+
+if [[ "${args[0]:-}" == influxdb3 ]] ; then
+    for i in "${!args[@]}"; do
+        args[i]="$(envsubst <<<"${args[i]}")"
+    done
+fi
+
+exec "${args[@]}"

--- a/influxdb/3.2-enterprise/Dockerfile
+++ b/influxdb/3.2-enterprise/Dockerfile
@@ -1,0 +1,56 @@
+FROM ubuntu:24.04
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y \
+        ca-certificates \
+        curl \
+        gettext-base \
+        gnupg \
+        libssl3 && \
+    rm -rf /var/lib/apt/lists*
+
+RUN groupadd --gid 1500 influxdb3 && \
+    useradd  --uid 1500 --gid influxdb3 --shell /bin/bash --create-home influxdb3 && \
+    mkdir -p /var/lib/influxdb3 \
+             /usr/lib/influxdb3 \
+             /plugins
+
+ENV INFLUXDB_VERSION=3.2.0
+RUN case "$(dpkg --print-architecture)" in \
+        amd64) ARCH=amd64 ;; \
+        arm64) ARCH=arm64 ;; \
+        *) echo 'Unsupported Architecture' ; exit 1 ;; \
+    esac && \
+    curl -fsSLO "https://dl.influxdata.com/influxdb/releases/influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
+         -fsSLO "https://dl.influxdata.com/influxdb/releases/influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \
+    # Verify InfluxDB3 Enterprise \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
+        # InfluxData Package Signing Key <support@influxdata.com> \
+        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E && \
+    gpg --batch --verify \
+        "influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
+        "influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \
+    # Install InfluxDB3 Enterprise \
+    tar --strip-components 1 -C /usr/lib/influxdb3 -xvf "influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \
+    mv /usr/lib/influxdb3/influxdb3 /usr/bin/influxdb3 && \
+    chown -R influxdb3:influxdb3 /var/lib/influxdb3 /plugins && \
+    chown -R root:root /usr/lib/influxdb3 && \
+    # Cleanup \
+    rm  "influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
+        "influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz"
+
+COPY entrypoint.sh /usr/bin/entrypoint.sh
+
+USER influxdb3
+RUN mkdir ~/.influxdb3
+
+ENV INFLUXDB3_PLUGIN_DIR=/plugins
+ENV INFLUXDB3_DATA_DIR=/home/influxdb3/.influxdb3
+ENV INFLUXDB_IOX_DB_DIR=/var/lib/influxdb3
+ENV LOG_FILTER=info
+
+EXPOSE 8181
+
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]
+CMD ["influxdb3", "serve"]

--- a/influxdb/3.2-enterprise/entrypoint.sh
+++ b/influxdb/3.2-enterprise/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+args=("${@}")
+
+if [[ "${args[0]:-}" == serve ]] ; then
+    args=(influxdb3 "${args[@]}")
+fi
+
+if [[ "${args[0]:-}" =~ ^- ]] ; then
+    args=(influxdb3 serve "${args[@]}")
+fi
+
+if [[ "${args[0]:-}" == influxdb3 ]] ; then
+    for i in "${!args[@]}"; do
+        args[i]="$(envsubst <<<"${args[i]}")"
+    done
+fi
+
+exec "${args[@]}"


### PR DESCRIPTION
Added 3.2.0-core and 3.2.0-enterprise. The plan is, this version will be tested till Monday next week and a final switch over to this release will be done Monday next week.

By merging this PR I'm assuming we can run `docker pull influxdb3:3.2.0-enterprise`. It is not clear if this will work only after updating the manifest as well. Also, I don't want to update the latest tag as we want to run controlled test till Monday. If my assumptions are incorrect please advise what steps to take or amendments to make to this PR.