### PR TITLE
chore: minimal commit to retrigger build as 3.2.0 has been retagged

### DIFF
--- a/influxdb/3.2-core/Dockerfile
+++ b/influxdb/3.2-core/Dockerfile
@@ -16,7 +16,9 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
+# The released version of influxdb3-core
 ENV INFLUXDB_VERSION=3.2.0
+
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \

--- a/influxdb/3.2-enterprise/Dockerfile
+++ b/influxdb/3.2-enterprise/Dockerfile
@@ -16,7 +16,9 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
+# The released version of influxdb3-enterprise
 ENV INFLUXDB_VERSION=3.2.0
+
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \


### PR DESCRIPTION
Added some comments to retrigger the build as we've re-tagged 3.2.0