### PR TITLE
chore: remove su-exec from chronograf

### DIFF
--- a/chronograf/1.10/alpine/Dockerfile
+++ b/chronograf/1.10/alpine/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:3.20
+FROM alpine:3.22
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache ca-certificates su-exec && \
+RUN apk add --no-cache ca-certificates setpriv && \
     update-ca-certificates
 
-ENV CHRONOGRAF_VERSION 1.10.7
+ENV CHRONOGRAF_VERSION=1.10.7
 
 RUN set -ex && \
     mkdir ~/.gnupg; \

--- a/chronograf/1.10/alpine/entrypoint.sh
+++ b/chronograf/1.10/alpine/entrypoint.sh
@@ -12,5 +12,5 @@ fi
 if [ "$(id -u)" -ne 0 ] || [ "${CHRONOGRAF_AS_ROOT}" = "true" ]; then
     exec "$@"
 else
-    exec setpriv --reuid chronograf --regid chronograf --init-groups chronograf "$@"
+    exec setpriv --reuid chronograf --regid chronograf --init-groups "$@"
 fi

--- a/chronograf/1.10/alpine/entrypoint.sh
+++ b/chronograf/1.10/alpine/entrypoint.sh
@@ -12,5 +12,5 @@ fi
 if [ "$(id -u)" -ne 0 ] || [ "${CHRONOGRAF_AS_ROOT}" = "true" ]; then
     exec "$@"
 else
-    exec su-exec chronograf "$@"
+    exec setpriv --reuid chronograf --regid chronograf --init-groups chronograf "$@"
 fi


### PR DESCRIPTION
In `Dockerfile` and in `entrypoint.sh` replace `su-exec` with `setpriv`, as one already done for kapacitor in PR #814 
