### PR TITLE
chore: update GPG to use the non-compat key

### DIFF
--- a/chronograf/1.10/Dockerfile
+++ b/chronograf/1.10/Dockerfile
@@ -6,7 +6,7 @@ RUN set -ex && \
     apt-get update && apt-get install -y gnupg ca-certificates dirmngr --no-install-recommends && \
     rm -rf /var/lib/apt/lists/* && \
     for key in \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E ; \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 ; \
     do \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done

--- a/chronograf/1.10/alpine/Dockerfile
+++ b/chronograf/1.10/alpine/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf; \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \
     for key in \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E ; \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 ; \
     do \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done && \

--- a/influxdb/1.10/data/Dockerfile
+++ b/influxdb/1.10/data/Dockerfile
@@ -4,7 +4,7 @@ RUN set -ex && \
     mkdir ~/.gnupg; \
     echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf; \
     for key in \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E ; \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 ; \
     do \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done

--- a/influxdb/1.10/data/alpine/Dockerfile
+++ b/influxdb/1.10/data/alpine/Dockerfile
@@ -8,7 +8,7 @@ ENV INFLUXDB_VERSION 1.10.8-c1.10.8
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \
     for key in \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E ; \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 ; \
     do \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done && \

--- a/influxdb/1.10/meta/Dockerfile
+++ b/influxdb/1.10/meta/Dockerfile
@@ -4,7 +4,7 @@ RUN set -ex && \
     mkdir ~/.gnupg; \
     echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf; \
     for key in \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E ; \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 ; \
     do \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done

--- a/influxdb/1.10/meta/alpine/Dockerfile
+++ b/influxdb/1.10/meta/alpine/Dockerfile
@@ -8,7 +8,7 @@ ENV INFLUXDB_VERSION 1.10.8-c1.10.8
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \
     for key in \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E ; \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 ; \
     do \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done && \

--- a/influxdb/1.11/Dockerfile
+++ b/influxdb/1.11/Dockerfile
@@ -4,7 +4,7 @@ RUN addgroup --system --gid 1500 influxdb && \
     adduser --system --uid 1500 --ingroup influxdb --home /var/lib/influxdb --shell /bin/false influxdb
 
 ARG INFLUXDB_VERSION=1.11.8
-RUN gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys 9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E && \
+RUN gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys 24C975CBA61A024EE1B631787C3D57159FC2F927 && \
     export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     case "$(dpkg --print-architecture)" in \

--- a/influxdb/1.11/alpine/Dockerfile
+++ b/influxdb/1.11/alpine/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache --virtual .build-deps \
       curl \
       gnupg \
       tar && \
-    gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys 9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E && \
+    gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys 24C975CBA61A024EE1B631787C3D57159FC2F927 && \
     case "$(apk --print-arch)" in \
       x86_64)  ARCH=amd64 ;; \
       aarch64) ARCH=arm64 ;; \

--- a/influxdb/1.11/data/Dockerfile
+++ b/influxdb/1.11/data/Dockerfile
@@ -4,7 +4,7 @@ RUN set -ex && \
     mkdir ~/.gnupg; \
     echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf; \
     for key in \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E ; \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 ; \
     do \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done

--- a/influxdb/1.11/data/alpine/Dockerfile
+++ b/influxdb/1.11/data/alpine/Dockerfile
@@ -8,7 +8,7 @@ ENV INFLUXDB_VERSION 1.11.8-c1.11.8
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \
     for key in \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E ; \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 ; \
     do \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done && \

--- a/influxdb/1.11/meta/Dockerfile
+++ b/influxdb/1.11/meta/Dockerfile
@@ -4,7 +4,7 @@ RUN set -ex && \
     mkdir ~/.gnupg; \
     echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf; \
     for key in \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E ; \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 ; \
     do \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done

--- a/influxdb/1.11/meta/alpine/Dockerfile
+++ b/influxdb/1.11/meta/alpine/Dockerfile
@@ -8,7 +8,7 @@ ENV INFLUXDB_VERSION 1.11.8-c1.11.8
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \
     for key in \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E ; \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 ; \
     do \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done && \

--- a/influxdb/1.12/Dockerfile
+++ b/influxdb/1.12/Dockerfile
@@ -15,7 +15,7 @@ RUN set -x && \
     # Verify InfluxDB 1.X OSS \
     gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys \
         # InfluxData Package Signing Key <support@influxdata.com> \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E && \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 && \
     gpg --batch --verify \
         "influxdb_${INFLUXDB_VERSION}-1_${ARCH}.deb.asc" \
         "influxdb_${INFLUXDB_VERSION}-1_${ARCH}.deb" && \

--- a/influxdb/1.12/alpine/Dockerfile
+++ b/influxdb/1.12/alpine/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --no-cache --virtual .build-deps curl gnupg tar && \
     # Verify InfluxDB 1.X OSS \
     gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys \
         # InfluxData Package Signing Key <support@influxdata.com> \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E && \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 && \
     gpg --batch --verify \
         "influxdb-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
         "influxdb-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \

--- a/influxdb/1.12/data/Dockerfile
+++ b/influxdb/1.12/data/Dockerfile
@@ -6,7 +6,7 @@ RUN curl -fsSLO "https://dl.influxdata.com/enterprise/releases/influxdb-data_${I
     # Verify InfluxDB 1.X Enterprise \
     gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys \
         # InfluxData Package Signing Key <support@influxdata.com> \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E && \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 && \
     gpg --batch --verify \
         "influxdb-data_${INFLUXDB_VERSION}-1_amd64.deb.asc" \
         "influxdb-data_${INFLUXDB_VERSION}-1_amd64.deb" && \

--- a/influxdb/1.12/data/alpine/Dockerfile
+++ b/influxdb/1.12/data/alpine/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache --virtual .build-deps curl gnupg tar && \
     # Verify InfluxDB 1.X Enterprise \
     gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys \
         # InfluxData Package Signing Key <support@influxdata.com> \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E && \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 && \
     gpg --batch --verify \
         "influxdb-data-${INFLUXDB_VERSION}_linux_amd64.tar.gz.asc" \
         "influxdb-data-${INFLUXDB_VERSION}_linux_amd64.tar.gz" && \

--- a/influxdb/1.12/meta/Dockerfile
+++ b/influxdb/1.12/meta/Dockerfile
@@ -6,7 +6,7 @@ RUN curl -fsSLO "https://dl.influxdata.com/enterprise/releases/influxdb-meta_${I
     # Verify InfluxDB 1.X Enterprise \
     gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys \
         # InfluxData Package Signing Key <support@influxdata.com> \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E && \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 && \
     gpg --batch --verify \
         "influxdb-meta_${INFLUXDB_VERSION}-1_amd64.deb.asc" \
         "influxdb-meta_${INFLUXDB_VERSION}-1_amd64.deb" && \

--- a/influxdb/1.12/meta/alpine/Dockerfile
+++ b/influxdb/1.12/meta/alpine/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache --virtual .build-deps curl gnupg tar && \
     # Verify InfluxDB 1.X Enterprise \
     gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys \
         # InfluxData Package Signing Key <support@influxdata.com> \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E && \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 && \
     gpg --batch --verify \
         "influxdb-meta-${INFLUXDB_VERSION}_linux_amd64.tar.gz.asc" \
         "influxdb-meta-${INFLUXDB_VERSION}_linux_amd64.tar.gz" && \

--- a/influxdb/2.7/Dockerfile
+++ b/influxdb/2.7/Dockerfile
@@ -58,7 +58,7 @@ RUN case "$(dpkg --print-architecture)" in \
     export GNUPGHOME="$(mktemp -d)" && \
     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
       # InfluxData Package Signing Key <support@influxdata.com>
-      9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E && \
+      24C975CBA61A024EE1B631787C3D57159FC2F927 && \
     curl -fLO "https://dl.influxdata.com/influxdb/releases/v${INFLUXDB_VERSION}/influxdb2-${INFLUXDB_VERSION}_linux_${arch}.tar.gz" \
          -fLO "https://dl.influxdata.com/influxdb/releases/v${INFLUXDB_VERSION}/influxdb2-${INFLUXDB_VERSION}_linux_${arch}.tar.gz.asc" && \
     gpg --batch --verify "influxdb2-${INFLUXDB_VERSION}_linux_${arch}.tar.gz.asc" \
@@ -80,7 +80,7 @@ RUN case "$(dpkg --print-architecture)" in \
     export GNUPGHOME="$(mktemp -d)" && \
     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
       # InfluxData Package Signing Key <support@influxdata.com>
-      9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E && \
+      24C975CBA61A024EE1B631787C3D57159FC2F927 && \
     curl -fLO "https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${arch}.tar.gz" \
          -fLO "https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${arch}.tar.gz.asc" && \
     gpg --batch --verify "influxdb2-client-${INFLUX_CLI_VERSION}-linux-${arch}.tar.gz.asc" \

--- a/influxdb/2.7/alpine/Dockerfile
+++ b/influxdb/2.7/alpine/Dockerfile
@@ -40,7 +40,7 @@ RUN case "$(apk --print-arch)" in \
     export GNUPGHOME="$(mktemp -d)" && \
     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
       # InfluxData Package Signing Key <support@influxdata.com>
-      9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E &&\
+      24C975CBA61A024EE1B631787C3D57159FC2F927 &&\
     curl -fLO "https://dl.influxdata.com/influxdb/releases/v${INFLUXDB_VERSION}/influxdb2-${INFLUXDB_VERSION}_linux_${arch}.tar.gz" \
          -fLO "https://dl.influxdata.com/influxdb/releases/v${INFLUXDB_VERSION}/influxdb2-${INFLUXDB_VERSION}_linux_${arch}.tar.gz.asc" && \
     gpg --batch --verify "influxdb2-${INFLUXDB_VERSION}_linux_${arch}.tar.gz.asc" \
@@ -62,7 +62,7 @@ RUN case "$(apk --print-arch)" in \
     export GNUPGHOME="$(mktemp -d)" && \
     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
       # InfluxData Package Signing Key <support@influxdata.com>
-      9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E && \
+      24C975CBA61A024EE1B631787C3D57159FC2F927 && \
     curl -fLO "https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${arch}.tar.gz" \
          -fLO "https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${arch}.tar.gz.asc" && \
     gpg --batch --verify "influxdb2-client-${INFLUX_CLI_VERSION}-linux-${arch}.tar.gz.asc" \

--- a/influxdb/3.4-core/Dockerfile
+++ b/influxdb/3.4-core/Dockerfile
@@ -27,7 +27,7 @@ RUN case "$(dpkg --print-architecture)" in \
     # Verify InfluxDB3 Core \
     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
         # InfluxData Package Signing Key <support@influxdata.com> \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E && \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 && \
     gpg --batch --verify \
         "influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
         "influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \

--- a/influxdb/3.4-enterprise/Dockerfile
+++ b/influxdb/3.4-enterprise/Dockerfile
@@ -27,7 +27,7 @@ RUN case "$(dpkg --print-architecture)" in \
     # Verify InfluxDB3 Enterprise \
     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
         # InfluxData Package Signing Key <support@influxdata.com> \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E && \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 && \
     gpg --batch --verify \
         "influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
         "influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \

--- a/kapacitor/1.8/Dockerfile
+++ b/kapacitor/1.8/Dockerfile
@@ -18,7 +18,7 @@ RUN set -eux && \
     wget --no-verbose https://dl.influxdata.com/kapacitor/releases/kapacitor_${KAPACITOR_VERSION}-1_${ARCH}.deb && \
     export GNUPGHOME="$(mktemp -d)" && \
     echo "disable-ipv6" >> $GNUPGHOME/dirmngr.conf && \
-    gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys 9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E && \
+    gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys 24C975CBA61A024EE1B631787C3D57159FC2F927 && \
     gpg --batch --verify kapacitor_${KAPACITOR_VERSION}-1_${ARCH}.deb.asc kapacitor_${KAPACITOR_VERSION}-1_${ARCH}.deb && \
     rm -rf "$GNUPGHOME" && \
     dpkg -i kapacitor_${KAPACITOR_VERSION}-1_${ARCH}.deb && \

--- a/kapacitor/1.8/alpine/Dockerfile
+++ b/kapacitor/1.8/alpine/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
     echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf; \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \
     for key in \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E ; \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 ; \
     do \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done && \

--- a/telegraf/1.34/Dockerfile
+++ b/telegraf/1.34/Dockerfile
@@ -8,7 +8,7 @@ RUN set -ex && \
     mkdir ~/.gnupg; \
     echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf; \
     for key in \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E ; \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 ; \
     do \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done

--- a/telegraf/1.34/alpine/Dockerfile
+++ b/telegraf/1.34/alpine/Dockerfile
@@ -17,7 +17,7 @@ RUN ARCH= && \
     echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf; \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \
     for key in \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E ; \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 ; \
     do \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done && \

--- a/telegraf/1.35/Dockerfile
+++ b/telegraf/1.35/Dockerfile
@@ -8,7 +8,7 @@ RUN set -ex && \
     mkdir ~/.gnupg; \
     echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf; \
     for key in \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E ; \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 ; \
     do \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done

--- a/telegraf/1.35/alpine/Dockerfile
+++ b/telegraf/1.35/alpine/Dockerfile
@@ -17,7 +17,7 @@ RUN ARCH= && \
     echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf; \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \
     for key in \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E ; \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 ; \
     do \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done && \

--- a/telegraf/1.36/Dockerfile
+++ b/telegraf/1.36/Dockerfile
@@ -8,7 +8,7 @@ RUN set -ex && \
     mkdir ~/.gnupg; \
     echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf; \
     for key in \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E ; \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 ; \
     do \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done

--- a/telegraf/1.36/alpine/Dockerfile
+++ b/telegraf/1.36/alpine/Dockerfile
@@ -17,7 +17,7 @@ RUN ARCH= && \
     echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf; \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \
     for key in \
-        9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E ; \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 ; \
     do \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done && \


### PR DESCRIPTION
https://repos.influxdata.com/ hosts two different keys:
* influxdata-archive.key
* influxdata-archive_compat.key

and the Dockerfiles in this repo specify the fingerprint of influxdata-archive_compat.key. This key expires in January 2026. Update the Dockerfiles to instead fetch the fingerprint of influxdata-archive.key (which uses signing subkeys) since our rotation processes will add the new signing subkey to this file (leaving the old, expired ones). Put another way, by updating to use influxdata-archive.key, we won't have to worry about changing these Dockerfiles when we periodically rotate.

Importantly, the influxdata-archive_compat.key is the extracted signing subkey from influxdata-archive.key. As such, the above change doesn't change anything wrt which signing key is being used to verify; it's only changing how we fetch that signing key.

I only updated the currently supported images and I rebuilt all of those after applying this patch, and everything builds fine (see [out.gz](https://github.com/user-attachments/files/22389971/out.gz))