### PR TITLE
feat(entrypoint): allow unsetting env vars

### DIFF
--- a/influxdb/3.6-enterprise/entrypoint.sh
+++ b/influxdb/3.6-enterprise/entrypoint.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
+# Unset environment variables; splitting on whitespace
+# Usage: INFLUXDB3_UNSET_VARS="HOST FOO BAR"
+if [[ -n "${INFLUXDB3_UNSET_VARS:-}" ]]; then
+    read -ra vars <<< "${INFLUXDB3_UNSET_VARS}"
+    for var in "${vars[@]}"; do
+        unset "$var" || { echo "Error: Failed to unset variable '$var' (may be readonly)"; exit 1; }
+    done
+fi
+
 args=("${@}")
 
 if [[ "${args[0]:-}" == serve ]] ; then


### PR DESCRIPTION
Allows clearing env vars that might have been set
in the container image or elsewhere.

This PR is against the 3.6 docker file which has already been released. I don't expect us to make a new docker image from this modified file; BUT because we copy'n'paste the previous docker files to create the new version, this change will appear in 3.7. 

* port of https://github.com/influxdata/influxdb_pro/pull/1650