### PR TITLE
chore(3-core): allow unsetting env vars

### DIFF
--- a/influxdb/3.7-core/entrypoint.sh
+++ b/influxdb/3.7-core/entrypoint.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
+# Unset environment variables; splitting on whitespace
+# Usage: INFLUXDB3_UNSET_VARS="HOST FOO BAR"
+if [[ -n "${INFLUXDB3_UNSET_VARS:-}" ]]; then
+    read -ra vars <<< "${INFLUXDB3_UNSET_VARS}"
+    for var in "${vars[@]}"; do
+        unset "$var" || { echo "Error: Failed to unset variable '$var' (may be readonly)"; exit 1; }
+    done
+fi
+
 args=("${@}")
 
 if [[ "${args[0]:-}" == serve ]] ; then


### PR DESCRIPTION
Ports #838 to core, which allows clearing env vars that might have been set in the container image.

* follows #838