### PR TITLE
chore: add docker images for OSS 2.8.0 and OSS 2.8 in general

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ workflows:
       - test-influxdb:
           matrix:
             parameters:
-              version: ["2.7"]
+              version: ["2.7", "2.8"]
       - publish_docker_images:
           <<: *master_filter
       - test-influxdb-binaries:
@@ -70,7 +70,7 @@ jobs:
     parameters:
       version:
         type: string
-        enum: ["2.7"]
+        enum: ["2.7", "2.8"]
     steps:
       - checkout
       - run: |

--- a/influxdb/2.8/Dockerfile
+++ b/influxdb/2.8/Dockerfile
@@ -1,0 +1,114 @@
+FROM debian:bookworm-slim
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    # install dependencies \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      gnupg && \
+    # cleanup apt \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install dasel for configuration parsing
+RUN case "$(dpkg --print-architecture)" in \
+      *amd64) arch=amd64 ;; \
+      *arm64) arch=arm64 ;; \
+      *) echo 'Unsupported architecture' && exit 1 ;; \
+    esac && \
+    curl -fL "https://github.com/TomWright/dasel/releases/download/v2.8.1/dasel_linux_${arch}.gz" | gzip -d > /usr/local/bin/dasel && \
+    case ${arch} in \
+      amd64) echo '21fda0a4dc3c779c42737eca4b37e4f187d7ab91ba6301eed97b801af84a9ea2  /usr/local/bin/dasel' ;; \
+      arm64) echo '2c75e63f9884c37578f48788819dda5a5a5c32ec6c4a663eefc19839f44d6291  /usr/local/bin/dasel' ;; \
+    esac | sha256sum -c - && \
+    chmod +x /usr/local/bin/dasel && \
+    dasel --version
+
+RUN groupadd -r influxdb --gid=1000 && \
+    useradd -r -g influxdb --uid=1000 --create-home --home-dir=/home/influxdb --shell=/bin/bash influxdb
+
+# Install gosu for easy step-down from root
+ENV GOSU_VER=1.16
+RUN case "$(dpkg --print-architecture)" in \
+      *amd64) arch=amd64 ;; \
+      *arm64) arch=arm64 ;; \
+      *) echo 'Unsupported architecture' && exit 1 ;; \
+    esac && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
+      # Tianon Gravi <tianon@tianon.xyz> (gosu)
+      B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
+    curl -fLo /usr/local/bin/gosu     "https://github.com/tianon/gosu/releases/download/$GOSU_VER/gosu-${arch}" \
+         -fLo /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VER/gosu-${arch}.asc" && \
+    gpg --batch --verify /usr/local/bin/gosu.asc \
+                         /usr/local/bin/gosu && \
+    rm -rf /usr/local/bin/gosu.asc && \
+    chmod +x /usr/local/bin/gosu && \
+    gosu --version && \
+    gosu nobody true
+
+# Install the influxd server
+ENV INFLUXDB_VERSION=2.8.0
+ENV INFLUXDB_PR=-2
+ENV INFLUXDB_PV=${INFLUXDB_VERSION}${INFLUXDB_PR}
+RUN case "$(dpkg --print-architecture)" in \
+      *amd64) arch=amd64 ;; \
+      *arm64) arch=arm64 ;; \
+      *) echo 'Unsupported architecture' && exit 1 ;; \
+    esac && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
+      # InfluxData Package Signing Key <support@influxdata.com>
+      24C975CBA61A024EE1B631787C3D57159FC2F927 && \
+    curl -fLO "https://dl.influxdata.com/influxdb/releases/v${INFLUXDB_VERSION}/influxdb2-${INFLUXDB_PV}_linux_${arch}.tar.gz" \
+         -fLO "https://dl.influxdata.com/influxdb/releases/v${INFLUXDB_VERSION}/influxdb2-${INFLUXDB_PV}_linux_${arch}.tar.gz.asc" && \
+    gpg --batch --verify "influxdb2-${INFLUXDB_PV}_linux_${arch}.tar.gz.asc" \
+                         "influxdb2-${INFLUXDB_PV}_linux_${arch}.tar.gz" && \
+    tar xzf "influxdb2-${INFLUXDB_PV}_linux_${arch}.tar.gz" && \
+    cp "influxdb2-${INFLUXDB_VERSION}/usr/bin/influxd" /usr/local/bin/influxd && \
+    rm -rf "influxdb2-${INFLUXDB_PV}_linux_${arch}.tar.gz" \
+           "influxdb2-${INFLUXDB_PV}_linux_${arch}.tar.gz.asc" \
+           "influxdb2-${INFLUXDB_VERSION}" && \
+    influxd version
+
+# Install the influx CLI
+ENV INFLUX_CLI_VERSION=2.7.5
+RUN case "$(dpkg --print-architecture)" in \
+      *amd64) arch=amd64 ;; \
+      *arm64) arch=arm64 ;; \
+      *) echo 'Unsupported architecture' && exit 1 ;; \
+    esac && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
+      # InfluxData Package Signing Key <support@influxdata.com>
+      24C975CBA61A024EE1B631787C3D57159FC2F927 && \
+    curl -fLO "https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${arch}.tar.gz" \
+         -fLO "https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${arch}.tar.gz.asc" && \
+    gpg --batch --verify "influxdb2-client-${INFLUX_CLI_VERSION}-linux-${arch}.tar.gz.asc" \
+                         "influxdb2-client-${INFLUX_CLI_VERSION}-linux-${arch}.tar.gz" && \
+    tar xzf "influxdb2-client-${INFLUX_CLI_VERSION}-linux-${arch}.tar.gz" -C /usr/local/bin ./influx && \
+    rm -rf "influxdb2-client-${INFLUX_CLI_VERSION}-linux-${arch}.tar.gz" \
+           "influxdb2-client-${INFLUX_CLI_VERSION}-linux-${arch}.tar.gz.asc" && \
+    influx version
+
+# Create standard directories expected by the entry-point.
+RUN mkdir /docker-entrypoint-initdb.d && \
+    mkdir -p /var/lib/influxdb2 && \
+    chown -R influxdb:influxdb /var/lib/influxdb2 && \
+    mkdir -p /etc/influxdb2 && \
+    chown -R influxdb:influxdb /etc/influxdb2
+VOLUME /var/lib/influxdb2 /etc/influxdb2
+
+COPY default-config.yml /etc/defaults/influxdb2/config.yml
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["influxd"]
+
+EXPOSE 8086
+
+ENV INFLUX_CONFIGS_PATH=/etc/influxdb2/influx-configs
+ENV INFLUXD_INIT_PORT=9999
+ENV INFLUXD_INIT_PING_ATTEMPTS=600
+ENV DOCKER_INFLUXDB_INIT_CLI_CONFIG_NAME=default

--- a/influxdb/2.8/alpine/Dockerfile
+++ b/influxdb/2.8/alpine/Dockerfile
@@ -1,0 +1,96 @@
+FROM alpine:3.21
+
+RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
+RUN apk add --no-cache \
+      bash \
+      ca-certificates \
+      curl \
+      gnupg \
+      run-parts \
+      su-exec \
+      tzdata && \
+    update-ca-certificates
+
+# Install dasel for configuration parsing
+RUN case "$(apk --print-arch)" in \
+      x86_64)  arch=amd64 ;; \
+      aarch64) arch=arm64 ;; \
+      *) echo 'Unsupported architecture' && exit 1 ;; \
+    esac && \
+    curl -fL "https://github.com/TomWright/dasel/releases/download/v2.8.1/dasel_linux_${arch}.gz" | gzip -d > /usr/local/bin/dasel && \
+    case ${arch} in \
+      amd64) echo '21fda0a4dc3c779c42737eca4b37e4f187d7ab91ba6301eed97b801af84a9ea2  /usr/local/bin/dasel' ;; \
+      arm64) echo '2c75e63f9884c37578f48788819dda5a5a5c32ec6c4a663eefc19839f44d6291  /usr/local/bin/dasel' ;; \
+    esac | sha256sum -c - && \
+    chmod +x /usr/local/bin/dasel && \
+    dasel --version
+
+RUN addgroup -S -g 1000 influxdb && \
+    adduser -S -G influxdb -u 1000 -h /home/influxdb -s /bin/sh influxdb && \
+    mkdir -p /home/influxdb && \
+    chown -R influxdb:influxdb /home/influxdb
+
+# Install the infuxd server
+ENV INFLUXDB_VERSION=2.8.0
+ENV INFLUXDB_PR=-2
+ENV INFLUXDB_PV=${INFLUXDB_VERSION}${INFLUXDB_PR}
+RUN case "$(apk --print-arch)" in \
+      x86_64)  arch=amd64 ;; \
+      aarch64) arch=arm64 ;; \
+      *) echo 'Unsupported architecture' && exit 1 ;; \
+    esac && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
+      # InfluxData Package Signing Key <support@influxdata.com>
+      24C975CBA61A024EE1B631787C3D57159FC2F927 &&\
+    curl -fLO "https://dl.influxdata.com/influxdb/releases/v${INFLUXDB_VERSION}/influxdb2-${INFLUXDB_PV}_linux_${arch}.tar.gz" \
+         -fLO "https://dl.influxdata.com/influxdb/releases/v${INFLUXDB_VERSION}/influxdb2-${INFLUXDB_PV}_linux_${arch}.tar.gz.asc" && \
+    gpg --batch --verify "influxdb2-${INFLUXDB_PV}_linux_${arch}.tar.gz.asc" \
+                         "influxdb2-${INFLUXDB_PV}_linux_${arch}.tar.gz" && \
+    tar xzf "influxdb2-${INFLUXDB_PV}_linux_${arch}.tar.gz" && \
+    cp "influxdb2-${INFLUXDB_VERSION}/usr/bin/influxd" /usr/local/bin/influxd && \
+    rm -rf "influxdb2-${INFLUXDB_PV}_linux_${arch}.tar.gz" \
+           "influxdb2-${INFLUXDB_PV}_linux_${arch}.tar.gz.asc" \
+           "influxdb2-${INFLUXDB_VERSION}" && \
+    influxd version
+
+# Install the influx CLI
+ENV INFLUX_CLI_VERSION=2.7.5
+RUN case "$(apk --print-arch)" in \
+      x86_64)  arch=amd64 ;; \
+      aarch64) arch=arm64 ;; \
+      *) echo 'Unsupported architecture' && exit 1 ;; \
+    esac && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
+      # InfluxData Package Signing Key <support@influxdata.com>
+      24C975CBA61A024EE1B631787C3D57159FC2F927 && \
+    curl -fLO "https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${arch}.tar.gz" \
+         -fLO "https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VERSION}-linux-${arch}.tar.gz.asc" && \
+    gpg --batch --verify "influxdb2-client-${INFLUX_CLI_VERSION}-linux-${arch}.tar.gz.asc" \
+                         "influxdb2-client-${INFLUX_CLI_VERSION}-linux-${arch}.tar.gz" && \
+    tar xzf "influxdb2-client-${INFLUX_CLI_VERSION}-linux-${arch}.tar.gz" -C /usr/local/bin ./influx && \
+    rm -rf "influxdb2-client-${INFLUX_CLI_VERSION}-linux-${arch}.tar.gz" \
+           "influxdb2-client-${INFLUX_CLI_VERSION}-linux-${arch}.tar.gz.asc" && \
+    influx version
+
+# Create standard directories expected by the entry-point.
+RUN mkdir /docker-entrypoint-initdb.d && \
+    mkdir -p /var/lib/influxdb2 && \
+    chown -R influxdb:influxdb /var/lib/influxdb2 && \
+    mkdir -p /etc/influxdb2 && \
+    chown -R influxdb:influxdb /etc/influxdb2
+VOLUME /var/lib/influxdb2 /etc/influxdb2
+
+COPY default-config.yml /etc/defaults/influxdb2/config.yml
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["influxd"]
+
+EXPOSE 8086
+
+ENV INFLUX_CONFIGS_PATH=/etc/influxdb2/influx-configs
+ENV INFLUXD_INIT_PORT=9999
+ENV INFLUXD_INIT_PING_ATTEMPTS=600
+ENV DOCKER_INFLUXDB_INIT_CLI_CONFIG_NAME=default

--- a/influxdb/2.8/alpine/default-config.yml
+++ b/influxdb/2.8/alpine/default-config.yml
@@ -1,0 +1,3 @@
+bolt-path: /var/lib/influxdb2/influxd.bolt
+engine-path: /var/lib/influxdb2/engine
+nats-port: 4222

--- a/influxdb/2.8/alpine/entrypoint.sh
+++ b/influxdb/2.8/alpine/entrypoint.sh
@@ -1,0 +1,501 @@
+#!/bin/bash
+set -eo pipefail
+
+## READ ME
+##
+## This script handles a few use-cases:
+##   1. Running arbitrary shell commands other than `influxd`
+##   2. Running subcommands of `influxd` other than `run`
+##   3. Running `influxd run` with no auto-setup or auto-upgrade behavior
+##   4. Running `influxd` with automated setup of a fresh 2.x DB
+##   5. Running `influxd` with automated upgrade from a 1.x DB
+##
+## Use-cases 4 and 5 both optionally support running user-mounted scripts against the
+## initialized DB to perform arbitrary setup logic.
+##
+## Use-case 1 runs as root (the container's default user). All other use-cases
+## run as a non-root user. To support this, the script attempts to handle chown-ing
+## the data directories specified in config/env/CLI flags. We do this even for
+## use-case 2 so that commands like `influxd inspect` which modify files in the data
+## directory don't create files will later be inaccessible to the main `influxd run`
+## process.
+##
+## Use-case 4 requires booting a temporary instance of `influxd` so we can access the
+## server's HTTP API. This script handles tracking the PID of that instance and shutting
+## it down appropriately. The instance is booted on a port other than what's specified in
+## config. We do this so:
+##   1. We can ignore any TLS settings in config while performing initial setup calls
+##   2. We don't have to worry about users accessing the DB before it's fully initialized
+##
+## Use-case 5 requires booting a temporary instance only when the user has mounted setup scripts.
+## If no scripts are present, we can `upgrade` and then immediately boot the server on the
+## user-configured port.
+
+
+# Do our best to match the logging requested by the user running the container.
+declare -rA LOG_LEVELS=( [error]=0 [warn]=1 [info]=2 [debug]=3 )
+declare LOG_LEVEL=error
+
+# Mimic the structured logging used by InfluxDB.
+# Usage: log <level> <msg> [<key> <val>]...
+function log () {
+    local -r level=$1 msg=$2
+    shift 2
+
+    if [ "${LOG_LEVELS[${level}]}" -gt "${LOG_LEVELS[${LOG_LEVEL}]}" ]; then
+        return
+    fi
+
+    local attrs='"system": "docker"'
+    while [ "$#" -gt 1 ]; do
+        attrs="${attrs}, \"$1\": \"$2\""
+        shift 2
+    done
+
+    local -r logtime="$(date --utc +'%FT%T.%NZ')"
+    1>&2 echo -e "${logtime}\t${level}\t${msg}\t{${attrs}}"
+}
+
+# Set the global log-level for the entry-point to match the config passed to influxd.
+function set_global_log_level () {
+    local level="$(influxd::config::get log-level "${@}")"
+
+    if [ -z "${level}" ] || [ -z "${LOG_LEVELS[${level}]}" ]; then
+      LOG_LEVEL=info
+    else
+      LOG_LEVEL=${level}
+    fi
+}
+
+# Look for standard config names in the volume configured in our Dockerfile.
+declare -r CONFIG_VOLUME=/etc/influxdb2
+declare -ra CONFIG_NAMES=(config.json config.toml config.yaml config.yml)
+
+# Search for a V2 config file, and export its path into the env for influxd to use.
+function set_config_path () {
+    local config_path=/etc/defaults/influxdb2/config.yml
+
+    if [ -n "$INFLUXD_CONFIG_PATH" ]; then
+        config_path="${INFLUXD_CONFIG_PATH}"
+    else
+        for name in "${CONFIG_NAMES[@]}"; do
+            if [ -f "${CONFIG_VOLUME}/${name}" ]; then
+                config_path="${CONFIG_VOLUME}/${name}"
+                break
+            fi
+        done
+    fi
+
+    export INFLUXD_CONFIG_PATH="${config_path}"
+}
+
+function influxd::config::get()
+{
+  # The configuration is a mixture of both configuration files, environment
+  # variables, and command line options. Consequentially, this prevents the
+  # configuration from being known *before* executing influxd. This
+  # emulates what `influx server-config` would return.
+  declare -r COLUMN_ENVIRONMENT=0
+  declare -r COLUMN_DEFAULT=1
+  declare -rA table=(
+    ##################################################################################
+    # PRIMARY_KEY       # ENVIRONMENT VARIABLE      # DEFAULT                        #
+    ##################################################################################
+            [bolt-path]=" INFLUXD_BOLT_PATH         | /var/lib/influxdb2/influxd.bolt"
+          [engine-path]=" INFLUXD_ENGINE_PATH       | /var/lib/influxdb2/engine"
+            [log-level]=" INFLUXD_LOG_LEVEL         | info"
+              [tls-key]=" INFLUXD_TLS_KEY           | "
+             [tls-cert]=" INFLUXD_TLS_CERT          | "
+    [http-bind-address]=" INFLUXD_HTTP_BIND_ADDRESS | :8086"
+  )
+
+  function table::get()
+  {
+    ( # don't leak shopt options
+      local row
+      local value
+
+      shopt -s extglob
+      # Unfortunately, bash doesn't support multidimensional arrays. This
+      # retrieves the corresponding row from the array, splits the column
+      # from row, and strips leading and trailing whitespace. `extglob`
+      # is required for this to delete multiple spaces.
+      IFS='|' row=(${table[${1}]})
+      value=${row[${2}]}
+      value="${value##+([[:space:]])}"
+      value="${value%%+([[:space:]])}"
+      echo "${value}"
+    )
+  }
+
+  #
+  # Parse Value from Arguments
+  #
+
+  local primary_key="${1}" && shift
+
+  # Command line arguments take precedence over all other configuration
+  # sources. This supports two argument formats and ignores unspecified
+  # arguments even if they contain errors. These will be caught when
+  # influxd is started.
+  while [[ "${#}" -gt 0 ]] ; do
+    case ${1} in
+      --${primary_key}=*) echo "${1/#"--${primary_key}="}" && return ;;
+      --${primary_key}* ) echo "${2}"                      && return ;;
+      *) shift ;;
+    esac
+  done
+
+  #
+  # Parse Value from Environment
+  #
+
+  local value
+
+  # If no command line arguments match, retrieve the corresponding environment
+  # variable. This differentiates between unset and empty variables. If empty,
+  # it is possible that variable was intentionally emptied; therefore, this
+  # returns nothing when empty.
+  value="$(table::get "${primary_key}" ${COLUMN_ENVIRONMENT})"
+  if [[ ${!value+x} ]] ; then
+    echo "${!value}" && return
+  fi
+
+  #
+  # Parse Value from Configuration
+  #
+
+  dasel -f "${INFLUXD_CONFIG_PATH}" -s "${primary_key}" -w - 2>/dev/null || \
+    table::get "${primary_key}" "${COLUMN_DEFAULT}"
+}
+
+function set_data_paths () {
+    BOLT_PATH="$(influxd::config::get bolt-path "${@}")"
+    ENGINE_PATH="$(influxd::config::get engine-path "${@}")"
+    export BOLT_PATH ENGINE_PATH
+}
+
+# Ensure all the data directories needed by influxd exist with the right permissions.
+function create_directories () {
+    local -r bolt_dir="$(dirname "${BOLT_PATH}")"
+    local user=$(id -u)
+
+    mkdir -p "${bolt_dir}" "${ENGINE_PATH}"
+    chmod 700 "${bolt_dir}" "${ENGINE_PATH}" || :
+
+    mkdir -p "${CONFIG_VOLUME}" || :
+    chmod 775 "${CONFIG_VOLUME}" || :
+
+    if [ ${user} = 0 ]; then
+        find "${bolt_dir}" \! -user influxdb -exec chown influxdb '{}' +
+        find "${ENGINE_PATH}" \! -user influxdb -exec chown influxdb '{}' +
+        find "${CONFIG_VOLUME}" \! -user influxdb -exec chown influxdb '{}' +
+    fi
+}
+
+# Read password and username from file to avoid unsecure env variables
+if [ -n "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}" ] && DOCKER_INFLUXDB_INIT_PASSWORD=$(cat "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}") || echo "DOCKER_INFLUXDB_INIT_PASSWORD_FILE defined, but file not existing, skipping."; fi
+if [ -n "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}" ] && DOCKER_INFLUXDB_INIT_USERNAME=$(cat "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}") || echo "DOCKER_INFLUXDB_INIT_USERNAME_FILE defined, but file not existing, skipping."; fi
+if [ -n "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}" ] && DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=$(cat "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}") || echo "DOCKER_INFLUXDB_INIT_USERNAME_FILE defined, but file not existing, skipping."; fi
+
+# List of env vars required to auto-run setup or upgrade processes.
+declare -ra REQUIRED_INIT_VARS=(
+  DOCKER_INFLUXDB_INIT_USERNAME
+  DOCKER_INFLUXDB_INIT_PASSWORD
+  DOCKER_INFLUXDB_INIT_ORG
+  DOCKER_INFLUXDB_INIT_BUCKET
+)
+
+# Ensure all env vars required to run influx setup or influxd upgrade are set in the env.
+function ensure_init_vars_set () {
+    local missing_some=0
+    for var in "${REQUIRED_INIT_VARS[@]}"; do
+        if [ -z "${!var}" ]; then
+            log error "missing parameter, cannot init InfluxDB" parameter ${var}
+            missing_some=1
+        fi
+    done
+    if [ ${missing_some} = 1 ]; then
+        exit 1
+    fi
+}
+
+# If exiting on error, delete all bolt and engine files.
+# If we didn't do this, the container would see the boltdb file on reboot and assume
+# the DB is already full set up.
+function cleanup_influxd () {
+    log warn "cleaning bolt and engine files to prevent conflicts on retry" bolt_path "${BOLT_PATH}" engine_path "${ENGINE_PATH}"
+    rm -rf "${BOLT_PATH}" "${ENGINE_PATH}/"*
+}
+
+# Upgrade V1 data into the V2 format using influxd upgrade.
+# The process will use either a V1 config file or a V1 data dir to drive
+# the upgrade, with precedence order:
+#   1. Config file pointed to by DOCKER_INFLUXDB_INIT_UPGRADE_V1_CONFIG env var
+#   2. Data dir pointed to by DOCKER_INFLUXDB_INIT_UPGRADE_V1_DIR env var
+#   3. Config file at /etc/influxdb/influxdb.conf
+#   4. Data dir at /var/lib/influxdb
+function upgrade_influxd () {
+    local -a upgrade_args=(
+        --force
+        --username "${DOCKER_INFLUXDB_INIT_USERNAME}"
+        --password "${DOCKER_INFLUXDB_INIT_PASSWORD}"
+        --org "${DOCKER_INFLUXDB_INIT_ORG}"
+        --bucket "${DOCKER_INFLUXDB_INIT_BUCKET}"
+        --v2-config-path "${CONFIG_VOLUME}/config.toml"
+        --influx-configs-path "${INFLUX_CONFIGS_PATH}"
+        --continuous-query-export-path "${CONFIG_VOLUME}/v1-cq-export.txt"
+        --log-path "${CONFIG_VOLUME}/upgrade.log"
+        --log-level "${LOG_LEVEL}"
+        --bolt-path "${BOLT_PATH}"
+        --engine-path "${ENGINE_PATH}"
+        --overwrite-existing-v2
+    )
+    if [ -n "${DOCKER_INFLUXDB_INIT_RETENTION}" ]; then
+        upgrade_args=("${upgrade_args[@]}" --retention "${DOCKER_INFLUXDB_INIT_RETENTION}")
+    fi
+    if [ -n "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN}" ]; then
+        upgrade_args=("${upgrade_args[@]}" --token "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN}")
+    fi
+
+    if [[ -n "${DOCKER_INFLUXDB_INIT_UPGRADE_V1_CONFIG}" && -f "${DOCKER_INFLUXDB_INIT_UPGRADE_V1_CONFIG}" ]]; then
+        upgrade_args=("${upgrade_args[@]}" --config-file "${DOCKER_INFLUXDB_INIT_UPGRADE_V1_CONFIG}")
+    elif [[ -n "${DOCKER_INFLUXDB_INIT_UPGRADE_V1_DIR}" && -d "${DOCKER_INFLUXDB_INIT_UPGRADE_V1_DIR}" ]]; then
+        upgrade_args=("${upgrade_args[@]}" --v1-dir "${DOCKER_INFLUXDB_INIT_UPGRADE_V1_DIR}")
+    elif [ -f /etc/influxdb/influxdb.conf ]; then
+        upgrade_args=("${upgrade_args[@]}" --config-file /etc/influxdb/influxdb.conf)
+    elif [ -d /var/lib/influxdb ]; then
+        upgrade_args=("${upgrade_args[@]}" --v1-dir /var/lib/influxdb)
+    else
+        log error "failed to autodetect usable V1 config or data dir, aborting upgrade"
+        exit 1
+    fi
+
+    influxd upgrade "${upgrade_args[@]}"
+
+    # Reset global influxd config to pick up new file written by the upgrade process.
+    set_config_path
+}
+
+# Ping influxd until it responds or crashes.
+# Used to block execution until the server is ready to process setup requests.
+function wait_for_influxd () {
+    local -r influxd_pid=$1
+    local ping_count=0
+    while kill -0 "${influxd_pid}" && [ ${ping_count} -lt ${INFLUXD_INIT_PING_ATTEMPTS} ]; do
+        sleep 1
+        log info "pinging influxd..." ping_attempt ${ping_count}
+        ping_count=$((ping_count+1))
+        if influx ping &> /dev/null; then
+            log info "got response from influxd, proceeding" total_pings ${ping_count}
+            return
+        fi
+    done
+    if [ ${ping_count} -eq ${INFLUXD_INIT_PING_ATTEMPTS} ]; then
+        log error "influxd took too long to start up" total_pings ${ping_count}
+    else
+        log error "influxd crashed during startup" total_pings ${ping_count}
+    fi
+    exit 1
+}
+
+# Create an initial user/org/bucket in the DB using the influx CLI.
+function setup_influxd () {
+    local -a setup_args=(
+        --force
+        --username "${DOCKER_INFLUXDB_INIT_USERNAME}"
+        --password "${DOCKER_INFLUXDB_INIT_PASSWORD}"
+        --org "${DOCKER_INFLUXDB_INIT_ORG}"
+        --bucket "${DOCKER_INFLUXDB_INIT_BUCKET}"
+        --name "${DOCKER_INFLUXDB_INIT_CLI_CONFIG_NAME}"
+    )
+    if [ -n "${DOCKER_INFLUXDB_INIT_RETENTION}" ]; then
+        setup_args=("${setup_args[@]}" --retention "${DOCKER_INFLUXDB_INIT_RETENTION}")
+    fi
+    if [ -n "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN}" ]; then
+        setup_args=("${setup_args[@]}" --token "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN}")
+    fi
+
+    influx setup "${setup_args[@]}"
+}
+
+# Get the IDs of the initial user/org/bucket created during setup, and export them into the env.
+# We do this to help with arbitrary user scripts, since many influx CLI commands only take IDs.
+function set_init_resource_ids () {
+    DOCKER_INFLUXDB_INIT_USER_ID="$(influx user list -n "${DOCKER_INFLUXDB_INIT_USER}" --hide-headers | cut -f 1)"
+    DOCKER_INFLUXDB_INIT_ORG_ID="$(influx org list -n "${DOCKER_INFLUXDB_INIT_ORG}" --hide-headers | cut -f 1)"
+    DOCKER_INFLUXDB_INIT_BUCKET_ID="$(influx bucket list -n "${DOCKER_INFLUXDB_INIT_BUCKET}" --hide-headers | cut -f 1)"
+    export DOCKER_INFLUXDB_INIT_USER_ID DOCKER_INFLUXDB_INIT_ORG_ID DOCKER_INFLUXDB_INIT_BUCKET_ID
+}
+
+# Allow users to mount arbitrary startup scripts into the container,
+# for execution after initial setup/upgrade.
+declare -r USER_SCRIPT_DIR=/docker-entrypoint-initdb.d
+
+# Check if user-defined setup scripts have been mounted into the container.
+function user_scripts_present () {
+    if [ ! -d ${USER_SCRIPT_DIR} ]; then
+        return 1
+    fi
+    test -n "$(find ${USER_SCRIPT_DIR} -name "*.sh" -type f -executable)"
+}
+
+# Execute all shell files mounted into the expected path for user-defined startup scripts.
+function run_user_scripts () {
+    if [ -d ${USER_SCRIPT_DIR} ]; then
+        log info "Executing user-provided scripts" script_dir ${USER_SCRIPT_DIR}
+        run-parts --regex ".*sh$" --report --exit-on-error ${USER_SCRIPT_DIR}
+    fi
+}
+
+# Helper used to propagate signals received during initialization to the influxd
+# process running in the background.
+function handle_signal () {
+    kill -${1} ${2}
+    wait ${2}
+}
+
+# Perform initial setup on the InfluxDB instance, either by setting up fresh metadata
+# or by upgrading existing V1 data.
+function init_influxd () {
+    if [[ "${DOCKER_INFLUXDB_INIT_MODE}" != setup && "${DOCKER_INFLUXDB_INIT_MODE}" != upgrade ]]; then
+        log error "found invalid DOCKER_INFLUXDB_INIT_MODE, valid values are 'setup' and 'upgrade'" DOCKER_INFLUXDB_INIT_MODE "${DOCKER_INFLUXDB_INIT_MODE}"
+        exit 1
+    fi
+    ensure_init_vars_set
+    trap "cleanup_influxd" EXIT
+
+    # The upgrade process needs to run before we boot the server, otherwise the
+    # boltdb file will be generated and cause conflicts.
+    if [ "${DOCKER_INFLUXDB_INIT_MODE}" = upgrade ]; then
+        upgrade_influxd
+    fi
+
+    # Short-circuit if using upgrade mode and user didn't define any custom scripts,
+    # to save startup time from booting & shutting down the server.
+    if [ "${DOCKER_INFLUXDB_INIT_MODE}" = upgrade ] && ! user_scripts_present; then
+        trap - EXIT
+        return
+    fi
+
+    local -r final_bind_addr="$(influxd::config::get http-bind-address "${@}")"
+    local -r init_bind_addr=":${INFLUXD_INIT_PORT}"
+    if [ "${init_bind_addr}" = "${final_bind_addr}" ]; then
+      log warn "influxd setup binding to same addr as final config, server will be exposed before ready" addr "${init_bind_addr}"
+    fi
+    local final_host_scheme="http"
+    if [ -n "$(influxd::config::get tls-cert "${@}")" ] &&
+       [ -n "$(influxd::config::get tls-key  "${@}")" ]
+    then
+      final_host_scheme="https"
+    fi
+
+    case ${INFLUXD_CONFIG_PATH,,} in
+      *.toml)       local influxd_config_format=toml ;;
+      *.json)       local influxd_config_format=json ;;
+      *.yaml|*.yml) local influxd_config_format=yaml ;;
+    esac
+
+    # Generate a config file with a known HTTP port, and TLS disabled.
+    local -r init_config=/tmp/config.json
+    (
+      dasel -r "${influxd_config_format}" -w json \
+        | dasel -r json put http-bind-address -v "${init_bind_addr}" \
+        `# insert "tls-cert" and "tls-key" so delete succeeds` \
+        | dasel -r json put tls-cert -v ''                     \
+        | dasel -r json put tls-key  -v ''                     \
+        `# delete "tls-cert" and "tls-key"` \
+        | dasel -r json delete tls-cert     \
+        | dasel -r json delete tls-key
+    ) <"${INFLUXD_CONFIG_PATH}" | tee "${init_config}"
+
+    # Start influxd in the background.
+    log info "booting influxd server in the background"
+    INFLUXD_CONFIG_PATH="${init_config}" INFLUXD_HTTP_BIND_ADDRESS="${init_bind_addr}" INFLUXD_TLS_CERT='' INFLUXD_TLS_KEY='' influxd &
+    local -r influxd_init_pid="$!"
+    trap "handle_signal TERM ${influxd_init_pid}" TERM
+    trap "handle_signal INT ${influxd_init_pid}" INT
+
+    export INFLUX_HOST="http://localhost:${INFLUXD_INIT_PORT}"
+    wait_for_influxd "${influxd_init_pid}"
+
+    # Use the influx CLI to create an initial user/org/bucket.
+    if [ "${DOCKER_INFLUXDB_INIT_MODE}" = setup ]; then
+        setup_influxd
+    fi
+
+    set_init_resource_ids
+    run_user_scripts
+
+    log info "initialization complete, shutting down background influxd"
+    kill -TERM "${influxd_init_pid}"
+    wait "${influxd_init_pid}" || true
+    trap - EXIT INT TERM
+
+    # Rewrite the CLI configs to point at the server's final HTTP address.
+    local -r final_port="$(echo "${final_bind_addr}" | sed -E 's#[^:]*:(.*)#\1#')"
+    sed -i "s#http://localhost:${INFLUXD_INIT_PORT}#${final_host_scheme}://localhost:${final_port}#g" "${INFLUX_CONFIGS_PATH}"
+}
+
+# Check if the --help or -h flag is set in a list of CLI args.
+function check_help_flag () {
+  for arg in "${@}"; do
+      if [ "${arg}" = --help ] || [ "${arg}" = -h ]; then
+          return 0
+      fi
+  done
+  return 1
+}
+
+function main () {
+    # Ensure INFLUXD_CONFIG_PATH is set.
+    # We do this even if we're not running the main influxd server so subcommands
+    # (i.e. print-config) still find the right config values.
+    set_config_path
+
+    local run_influxd=false
+    if [[ $# = 0 || "$1" = run || "${1:0:1}" = '-' ]]; then
+        run_influxd=true
+    elif [[ "$1" = influxd && ($# = 1 || "$2" = run || "${2:0:1}" = '-') ]]; then
+        run_influxd=true
+        shift 1
+    fi
+
+    if ! ${run_influxd}; then
+      exec "${@}"
+    fi
+
+    if [ "$1" = run ]; then
+        shift 1
+    fi
+
+    if ! check_help_flag "${@}"; then
+        # Configure logging for our wrapper.
+        set_global_log_level "${@}"
+        # Configure data paths used across functions.
+        set_data_paths "${@}"
+        # Ensure volume directories exist w/ correct permissions.
+        create_directories
+    fi
+
+    if [ -f "${BOLT_PATH}" ]; then
+        log info "found existing boltdb file, skipping setup wrapper" bolt_path "${BOLT_PATH}"
+    elif [ -z "${DOCKER_INFLUXDB_INIT_MODE}" ]; then
+        log warn "boltdb not found at configured path, but DOCKER_INFLUXDB_INIT_MODE not specified, skipping setup wrapper" bolt_path "${BOLT_PATH}"
+    else
+        init_influxd "${@}"
+        # Set correct permission on volume directories again. This is necessary so that if the container was run as the
+        # root user, the files from the automatic upgrade/initialization will be correctly set when stepping down to the
+        # influxdb user.
+        create_directories
+    fi
+
+    if [ "$(id -u)" = 0 ]; then
+        exec su-exec influxdb "$BASH_SOURCE" "${@}"
+    fi
+
+    # Run influxd.
+    exec influxd "${@}"
+}
+
+main "${@}"

--- a/influxdb/2.8/default-config.yml
+++ b/influxdb/2.8/default-config.yml
@@ -1,0 +1,3 @@
+bolt-path: /var/lib/influxdb2/influxd.bolt
+engine-path: /var/lib/influxdb2/engine
+nats-port: 4222

--- a/influxdb/2.8/entrypoint.sh
+++ b/influxdb/2.8/entrypoint.sh
@@ -1,0 +1,500 @@
+#!/bin/bash
+set -eo pipefail
+
+## READ ME
+##
+## This script handles a few use-cases:
+##   1. Running arbitrary shell commands other than `influxd`
+##   2. Running subcommands of `influxd` other than `run`
+##   3. Running `influxd run` with no auto-setup or auto-upgrade behavior
+##   4. Running `influxd` with automated setup of a fresh 2.x DB
+##   5. Running `influxd` with automated upgrade from a 1.x DB
+##
+## Use-cases 4 and 5 both optionally support running user-mounted scripts against the
+## initialized DB to perform arbitrary setup logic.
+##
+## Use-case 1 runs as root (the container's default user). All other use-cases
+## run as a non-root user. To support this, the script attempts to handle chown-ing
+## the data directories specified in config/env/CLI flags. We do this even for
+## use-case 2 so that commands like `influxd inspect` which modify files in the data
+## directory don't create files will later be inaccessible to the main `influxd run`
+## process.
+##
+## Use-case 4 requires booting a temporary instance of `influxd` so we can access the
+## server's HTTP API. This script handles tracking the PID of that instance and shutting
+## it down appropriately. The instance is booted on a port other than what's specified in
+## config. We do this so:
+##   1. We can ignore any TLS settings in config while performing initial setup calls
+##   2. We don't have to worry about users accessing the DB before it's fully initialized
+##
+## Use-case 5 requires booting a temporary instance only when the user has mounted setup scripts.
+## If no scripts are present, we can `upgrade` and then immediately boot the server on the
+## user-configured port.
+
+
+# Do our best to match the logging requested by the user running the container.
+declare -rA LOG_LEVELS=( [error]=0 [warn]=1 [info]=2 [debug]=3 )
+declare LOG_LEVEL=error
+
+# Mimic the structured logging used by InfluxDB.
+# Usage: log <level> <msg> [<key> <val>]...
+function log () {
+    local -r level=$1 msg=$2
+    shift 2
+
+    if [ "${LOG_LEVELS[${level}]}" -gt "${LOG_LEVELS[${LOG_LEVEL}]}" ]; then
+        return
+    fi
+
+    local attrs='"system": "docker"'
+    while [ "$#" -gt 1 ]; do
+        attrs="${attrs}, \"$1\": \"$2\""
+        shift 2
+    done
+
+    local -r logtime="$(date --utc +'%FT%T.%NZ')"
+    1>&2 echo -e "${logtime}\t${level}\t${msg}\t{${attrs}}"
+}
+
+# Set the global log-level for the entry-point to match the config passed to influxd.
+function set_global_log_level () {
+    local level="$(influxd::config::get log-level "${@}")"
+
+    if [ -z "${level}" ] || [ -z "${LOG_LEVELS[${level}]}" ]; then
+      LOG_LEVEL=info
+    else
+      LOG_LEVEL=${level}
+    fi
+}
+
+# Look for standard config names in the volume configured in our Dockerfile.
+declare -r CONFIG_VOLUME=/etc/influxdb2
+declare -ra CONFIG_NAMES=(config.json config.toml config.yaml config.yml)
+
+# Search for a V2 config file, and export its path into the env for influxd to use.
+function set_config_path () {
+    local config_path=/etc/defaults/influxdb2/config.yml
+
+    if [ -n "$INFLUXD_CONFIG_PATH" ]; then
+        config_path="${INFLUXD_CONFIG_PATH}"
+    else
+        for name in "${CONFIG_NAMES[@]}"; do
+            if [ -f "${CONFIG_VOLUME}/${name}" ]; then
+                config_path="${CONFIG_VOLUME}/${name}"
+                break
+            fi
+        done
+    fi
+
+    export INFLUXD_CONFIG_PATH="${config_path}"
+}
+
+function influxd::config::get()
+{
+  # The configuration is a mixture of both configuration files, environment
+  # variables, and command line options. Consequentially, this prevents the
+  # configuration from being known *before* executing influxd. This
+  # emulates what `influx server-config` would return.
+  declare -r COLUMN_ENVIRONMENT=0
+  declare -r COLUMN_DEFAULT=1
+  declare -rA table=(
+    ##################################################################################
+    # PRIMARY_KEY       # ENVIRONMENT VARIABLE      # DEFAULT                        #
+    ##################################################################################
+            [bolt-path]=" INFLUXD_BOLT_PATH         | /var/lib/influxdb2/influxd.bolt"
+          [engine-path]=" INFLUXD_ENGINE_PATH       | /var/lib/influxdb2/engine"
+            [log-level]=" INFLUXD_LOG_LEVEL         | info"
+              [tls-key]=" INFLUXD_TLS_KEY           | "
+             [tls-cert]=" INFLUXD_TLS_CERT          | "
+    [http-bind-address]=" INFLUXD_HTTP_BIND_ADDRESS | :8086"
+  )
+
+  function table::get()
+  {
+    ( # don't leak shopt options
+      local row
+      local value
+
+      shopt -s extglob
+      # Unfortunately, bash doesn't support multidimensional arrays. This
+      # retrieves the corresponding row from the array, splits the column
+      # from row, and strips leading and trailing whitespace. `extglob`
+      # is required for this to delete multiple spaces.
+      IFS='|' row=(${table[${1}]})
+      value=${row[${2}]}
+      value="${value##+([[:space:]])}"
+      value="${value%%+([[:space:]])}"
+      echo "${value}"
+    )
+  }
+
+  #
+  # Parse Value from Arguments
+  #
+
+  local primary_key="${1}" && shift
+
+  # Command line arguments take precedence over all other configuration
+  # sources. This supports two argument formats and ignores unspecified
+  # arguments even if they contain errors. These will be caught when
+  # influxd is started.
+  while [[ "${#}" -gt 0 ]] ; do
+    case ${1} in
+      --${primary_key}=*) echo "${1/#"--${primary_key}="}" && return ;;
+      --${primary_key}* ) echo "${2}"                      && return ;;
+      *) shift ;;
+    esac
+  done
+
+  #
+  # Parse Value from Environment
+  #
+
+  local value
+
+  # If no command line arguments match, retrieve the corresponding environment
+  # variable. This differentiates between unset and empty variables. If empty,
+  # it is possible that variable was intentionally emptied; therefore, this
+  # returns nothing when empty.
+  value="$(table::get "${primary_key}" ${COLUMN_ENVIRONMENT})"
+  if [[ ${!value+x} ]] ; then
+    echo "${!value}" && return
+  fi
+
+  #
+  # Parse Value from Configuration
+  #
+  dasel -f "${INFLUXD_CONFIG_PATH}" -s "${primary_key}" -w - 2>/dev/null || \
+    table::get "${primary_key}" "${COLUMN_DEFAULT}"
+}
+
+function set_data_paths () {
+    BOLT_PATH="$(influxd::config::get bolt-path "${@}")"
+    ENGINE_PATH="$(influxd::config::get engine-path "${@}")"
+    export BOLT_PATH ENGINE_PATH
+}
+
+# Ensure all the data directories needed by influxd exist with the right permissions.
+function create_directories () {
+    local -r bolt_dir="$(dirname "${BOLT_PATH}")"
+    local user=$(id -u)
+
+    mkdir -p "${bolt_dir}" "${ENGINE_PATH}"
+    chmod 700 "${bolt_dir}" "${ENGINE_PATH}" || :
+
+    mkdir -p "${CONFIG_VOLUME}" || :
+    chmod 775 "${CONFIG_VOLUME}" || :
+
+    if [ ${user} = 0 ]; then
+        find "${bolt_dir}" \! -user influxdb -exec chown influxdb '{}' +
+        find "${ENGINE_PATH}" \! -user influxdb -exec chown influxdb '{}' +
+        find "${CONFIG_VOLUME}" \! -user influxdb -exec chown influxdb '{}' +
+    fi
+}
+
+# Read password and username from file to avoid unsecure env variables
+if [ -n "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}" ] && DOCKER_INFLUXDB_INIT_PASSWORD=$(cat "${DOCKER_INFLUXDB_INIT_PASSWORD_FILE}") || echo "DOCKER_INFLUXDB_INIT_PASSWORD_FILE defined, but file not existing, skipping."; fi
+if [ -n "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}" ] && DOCKER_INFLUXDB_INIT_USERNAME=$(cat "${DOCKER_INFLUXDB_INIT_USERNAME_FILE}") || echo "DOCKER_INFLUXDB_INIT_USERNAME_FILE defined, but file not existing, skipping."; fi
+if [ -n "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}" ]; then [ -e "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}" ] && DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=$(cat "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE}") || echo "DOCKER_INFLUXDB_INIT_ADMIN_TOKEN_FILE defined, but file not existing, skipping."; fi
+
+# List of env vars required to auto-run setup or upgrade processes.
+declare -ra REQUIRED_INIT_VARS=(
+  DOCKER_INFLUXDB_INIT_USERNAME
+  DOCKER_INFLUXDB_INIT_PASSWORD
+  DOCKER_INFLUXDB_INIT_ORG
+  DOCKER_INFLUXDB_INIT_BUCKET
+)
+
+# Ensure all env vars required to run influx setup or influxd upgrade are set in the env.
+function ensure_init_vars_set () {
+    local missing_some=0
+    for var in "${REQUIRED_INIT_VARS[@]}"; do
+        if [ -z "${!var}" ]; then
+            log error "missing parameter, cannot init InfluxDB" parameter ${var}
+            missing_some=1
+        fi
+    done
+    if [ ${missing_some} = 1 ]; then
+        exit 1
+    fi
+}
+
+# If exiting on error, delete all bolt and engine files.
+# If we didn't do this, the container would see the boltdb file on reboot and assume
+# the DB is already full set up.
+function cleanup_influxd () {
+    log warn "cleaning bolt and engine files to prevent conflicts on retry" bolt_path "${BOLT_PATH}" engine_path "${ENGINE_PATH}"
+    rm -rf "${BOLT_PATH}" "${ENGINE_PATH}/"*
+}
+
+# Upgrade V1 data into the V2 format using influxd upgrade.
+# The process will use either a V1 config file or a V1 data dir to drive
+# the upgrade, with precedence order:
+#   1. Config file pointed to by DOCKER_INFLUXDB_INIT_UPGRADE_V1_CONFIG env var
+#   2. Data dir pointed to by DOCKER_INFLUXDB_INIT_UPGRADE_V1_DIR env var
+#   3. Config file at /etc/influxdb/influxdb.conf
+#   4. Data dir at /var/lib/influxdb
+function upgrade_influxd () {
+    local -a upgrade_args=(
+        --force
+        --username "${DOCKER_INFLUXDB_INIT_USERNAME}"
+        --password "${DOCKER_INFLUXDB_INIT_PASSWORD}"
+        --org "${DOCKER_INFLUXDB_INIT_ORG}"
+        --bucket "${DOCKER_INFLUXDB_INIT_BUCKET}"
+        --v2-config-path "${CONFIG_VOLUME}/config.toml"
+        --influx-configs-path "${INFLUX_CONFIGS_PATH}"
+        --continuous-query-export-path "${CONFIG_VOLUME}/v1-cq-export.txt"
+        --log-path "${CONFIG_VOLUME}/upgrade.log"
+        --log-level "${LOG_LEVEL}"
+        --bolt-path "${BOLT_PATH}"
+        --engine-path "${ENGINE_PATH}"
+        --overwrite-existing-v2
+    )
+    if [ -n "${DOCKER_INFLUXDB_INIT_RETENTION}" ]; then
+        upgrade_args=("${upgrade_args[@]}" --retention "${DOCKER_INFLUXDB_INIT_RETENTION}")
+    fi
+    if [ -n "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN}" ]; then
+        upgrade_args=("${upgrade_args[@]}" --token "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN}")
+    fi
+
+    if [[ -n "${DOCKER_INFLUXDB_INIT_UPGRADE_V1_CONFIG}" && -f "${DOCKER_INFLUXDB_INIT_UPGRADE_V1_CONFIG}" ]]; then
+        upgrade_args=("${upgrade_args[@]}" --config-file "${DOCKER_INFLUXDB_INIT_UPGRADE_V1_CONFIG}")
+    elif [[ -n "${DOCKER_INFLUXDB_INIT_UPGRADE_V1_DIR}" && -d "${DOCKER_INFLUXDB_INIT_UPGRADE_V1_DIR}" ]]; then
+        upgrade_args=("${upgrade_args[@]}" --v1-dir "${DOCKER_INFLUXDB_INIT_UPGRADE_V1_DIR}")
+    elif [ -f /etc/influxdb/influxdb.conf ]; then
+        upgrade_args=("${upgrade_args[@]}" --config-file /etc/influxdb/influxdb.conf)
+    elif [ -d /var/lib/influxdb ]; then
+        upgrade_args=("${upgrade_args[@]}" --v1-dir /var/lib/influxdb)
+    else
+        log error "failed to autodetect usable V1 config or data dir, aborting upgrade"
+        exit 1
+    fi
+
+    influxd upgrade "${upgrade_args[@]}"
+
+    # Reset global influxd config to pick up new file written by the upgrade process.
+    set_config_path
+}
+
+# Ping influxd until it responds or crashes.
+# Used to block execution until the server is ready to process setup requests.
+function wait_for_influxd () {
+    local -r influxd_pid=$1
+    local ping_count=0
+    while kill -0 "${influxd_pid}" && [ ${ping_count} -lt ${INFLUXD_INIT_PING_ATTEMPTS} ]; do
+        sleep 1
+        log info "pinging influxd..." ping_attempt ${ping_count}
+        ping_count=$((ping_count+1))
+        if influx ping &> /dev/null; then
+            log info "got response from influxd, proceeding" total_pings ${ping_count}
+            return
+        fi
+    done
+    if [ ${ping_count} -eq ${INFLUXD_INIT_PING_ATTEMPTS} ]; then
+        log error "influxd took too long to start up" total_pings ${ping_count}
+    else
+        log error "influxd crashed during startup" total_pings ${ping_count}
+    fi
+    exit 1
+}
+
+# Create an initial user/org/bucket in the DB using the influx CLI.
+function setup_influxd () {
+    local -a setup_args=(
+        --force
+        --username "${DOCKER_INFLUXDB_INIT_USERNAME}"
+        --password "${DOCKER_INFLUXDB_INIT_PASSWORD}"
+        --org "${DOCKER_INFLUXDB_INIT_ORG}"
+        --bucket "${DOCKER_INFLUXDB_INIT_BUCKET}"
+        --name "${DOCKER_INFLUXDB_INIT_CLI_CONFIG_NAME}"
+    )
+    if [ -n "${DOCKER_INFLUXDB_INIT_RETENTION}" ]; then
+        setup_args=("${setup_args[@]}" --retention "${DOCKER_INFLUXDB_INIT_RETENTION}")
+    fi
+    if [ -n "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN}" ]; then
+        setup_args=("${setup_args[@]}" --token "${DOCKER_INFLUXDB_INIT_ADMIN_TOKEN}")
+    fi
+
+    influx setup "${setup_args[@]}"
+}
+
+# Get the IDs of the initial user/org/bucket created during setup, and export them into the env.
+# We do this to help with arbitrary user scripts, since many influx CLI commands only take IDs.
+function set_init_resource_ids () {
+    DOCKER_INFLUXDB_INIT_USER_ID="$(influx user list -n "${DOCKER_INFLUXDB_INIT_USER}" --hide-headers | cut -f 1)"
+    DOCKER_INFLUXDB_INIT_ORG_ID="$(influx org list -n "${DOCKER_INFLUXDB_INIT_ORG}" --hide-headers | cut -f 1)"
+    DOCKER_INFLUXDB_INIT_BUCKET_ID="$(influx bucket list -n "${DOCKER_INFLUXDB_INIT_BUCKET}" --hide-headers | cut -f 1)"
+    export DOCKER_INFLUXDB_INIT_USER_ID DOCKER_INFLUXDB_INIT_ORG_ID DOCKER_INFLUXDB_INIT_BUCKET_ID
+}
+
+# Allow users to mount arbitrary startup scripts into the container,
+# for execution after initial setup/upgrade.
+declare -r USER_SCRIPT_DIR=/docker-entrypoint-initdb.d
+
+# Check if user-defined setup scripts have been mounted into the container.
+function user_scripts_present () {
+    if [ ! -d ${USER_SCRIPT_DIR} ]; then
+        return 1
+    fi
+    test -n "$(find ${USER_SCRIPT_DIR} -name "*.sh" -type f -executable)"
+}
+
+# Execute all shell files mounted into the expected path for user-defined startup scripts.
+function run_user_scripts () {
+    if [ -d ${USER_SCRIPT_DIR} ]; then
+        log info "Executing user-provided scripts" script_dir ${USER_SCRIPT_DIR}
+        run-parts --regex ".*sh$" --report --exit-on-error ${USER_SCRIPT_DIR}
+    fi
+}
+
+# Helper used to propagate signals received during initialization to the influxd
+# process running in the background.
+function handle_signal () {
+    kill -${1} ${2}
+    wait ${2}
+}
+
+# Perform initial setup on the InfluxDB instance, either by setting up fresh metadata
+# or by upgrading existing V1 data.
+function init_influxd () {
+    if [[ "${DOCKER_INFLUXDB_INIT_MODE}" != setup && "${DOCKER_INFLUXDB_INIT_MODE}" != upgrade ]]; then
+        log error "found invalid DOCKER_INFLUXDB_INIT_MODE, valid values are 'setup' and 'upgrade'" DOCKER_INFLUXDB_INIT_MODE "${DOCKER_INFLUXDB_INIT_MODE}"
+        exit 1
+    fi
+    ensure_init_vars_set
+    trap "cleanup_influxd" EXIT
+
+    # The upgrade process needs to run before we boot the server, otherwise the
+    # boltdb file will be generated and cause conflicts.
+    if [ "${DOCKER_INFLUXDB_INIT_MODE}" = upgrade ]; then
+        upgrade_influxd
+    fi
+
+    # Short-circuit if using upgrade mode and user didn't define any custom scripts,
+    # to save startup time from booting & shutting down the server.
+    if [ "${DOCKER_INFLUXDB_INIT_MODE}" = upgrade ] && ! user_scripts_present; then
+        trap - EXIT
+        return
+    fi
+
+    local -r final_bind_addr="$(influxd::config::get http-bind-address "${@}")"
+    local -r init_bind_addr=":${INFLUXD_INIT_PORT}"
+    if [ "${init_bind_addr}" = "${final_bind_addr}" ]; then
+      log warn "influxd setup binding to same addr as final config, server will be exposed before ready" addr "${init_bind_addr}"
+    fi
+    local final_host_scheme="http"
+    if [ -n "$(influxd::config::get tls-cert "${@}")" ] &&
+       [ -n "$(influxd::config::get tls-key  "${@}")" ]
+    then
+      final_host_scheme="https"
+    fi
+
+    case ${INFLUXD_CONFIG_PATH,,} in
+      *.toml)       local influxd_config_format=toml ;;
+      *.json)       local influxd_config_format=json ;;
+      *.yaml|*.yml) local influxd_config_format=yaml ;;
+    esac
+
+    # Generate a config file with a known HTTP port, and TLS disabled.
+    local -r init_config=/tmp/config.json
+    (
+      dasel -r "${influxd_config_format}" -w json \
+        | dasel -r json put http-bind-address -v "${init_bind_addr}" \
+        `# insert "tls-cert" and "tls-key" so delete succeeds` \
+        | dasel -r json put tls-cert -v ''                     \
+        | dasel -r json put tls-key  -v ''                     \
+        `# delete "tls-cert" and "tls-key"` \
+        | dasel -r json delete tls-cert     \
+        | dasel -r json delete tls-key
+    ) <"${INFLUXD_CONFIG_PATH}" | tee "${init_config}"
+
+    # Start influxd in the background.
+    log info "booting influxd server in the background"
+    INFLUXD_CONFIG_PATH="${init_config}" INFLUXD_HTTP_BIND_ADDRESS="${init_bind_addr}" INFLUXD_TLS_CERT='' INFLUXD_TLS_KEY='' influxd &
+    local -r influxd_init_pid="$!"
+    trap "handle_signal TERM ${influxd_init_pid}" TERM
+    trap "handle_signal INT ${influxd_init_pid}" INT
+
+    export INFLUX_HOST="http://localhost:${INFLUXD_INIT_PORT}"
+    wait_for_influxd "${influxd_init_pid}"
+
+    # Use the influx CLI to create an initial user/org/bucket.
+    if [ "${DOCKER_INFLUXDB_INIT_MODE}" = setup ]; then
+        setup_influxd
+    fi
+
+    set_init_resource_ids
+    run_user_scripts
+
+    log info "initialization complete, shutting down background influxd"
+    kill -TERM "${influxd_init_pid}"
+    wait "${influxd_init_pid}" || true
+    trap - EXIT INT TERM
+
+    # Rewrite the CLI configs to point at the server's final HTTP address.
+    local -r final_port="$(echo "${final_bind_addr}" | sed -E 's#[^:]*:(.*)#\1#')"
+    sed -i "s#http://localhost:${INFLUXD_INIT_PORT}#${final_host_scheme}://localhost:${final_port}#g" "${INFLUX_CONFIGS_PATH}"
+}
+
+# Check if the --help or -h flag is set in a list of CLI args.
+function check_help_flag () {
+  for arg in "${@}"; do
+      if [ "${arg}" = --help ] || [ "${arg}" = -h ]; then
+          return 0
+      fi
+  done
+  return 1
+}
+
+function main () {
+    # Ensure INFLUXD_CONFIG_PATH is set.
+    # We do this even if we're not running the main influxd server so subcommands
+    # (i.e. print-config) still find the right config values.
+    set_config_path
+
+    local run_influxd=false
+    if [[ $# = 0 || "$1" = run || "${1:0:1}" = '-' ]]; then
+        run_influxd=true
+    elif [[ "$1" = influxd && ($# = 1 || "$2" = run || "${2:0:1}" = '-') ]]; then
+        run_influxd=true
+        shift 1
+    fi
+
+    if ! ${run_influxd}; then
+      exec "${@}"
+    fi
+
+    if [ "$1" = run ]; then
+        shift 1
+    fi
+
+    if ! check_help_flag "${@}"; then
+        # Configure logging for our wrapper.
+        set_global_log_level "${@}"
+        # Configure data paths used across functions.
+        set_data_paths "${@}"
+        # Ensure volume directories exist w/ correct permissions.
+        create_directories
+    fi
+
+    if [ -f "${BOLT_PATH}" ]; then
+        log info "found existing boltdb file, skipping setup wrapper" bolt_path "${BOLT_PATH}"
+    elif [ -z "${DOCKER_INFLUXDB_INIT_MODE}" ]; then
+        log warn "boltdb not found at configured path, but DOCKER_INFLUXDB_INIT_MODE not specified, skipping setup wrapper" bolt_path "${BOLT_PATH}"
+    else
+        init_influxd "${@}"
+        # Set correct permission on volume directories again. This is necessary so that if the container was run as the
+        # root user, the files from the automatic upgrade/initialization will be correctly set when stepping down to the
+        # influxdb user.
+        create_directories
+    fi
+
+    if [ "$(id -u)" = 0 ]; then
+        exec gosu influxdb "$BASH_SOURCE" "${@}"
+    fi
+
+    # Run influxd.
+    exec influxd "${@}"
+}
+
+main "${@}"


### PR DESCRIPTION
Add Docker images for OSS 2.8.0 and the OSS 2.8 branch.

Also fixed a bug compared to the 2.7 images that caused the contents of the release tarball to be left behind in the Docker image. This was obviously a unintentional. The corresponding bug in the 2.7 Dockerfiles has not been fixed.
