### PR TITLE
chore: bump influxdb3 core and enterprise to 3.9.1

### DIFF
--- a/influxdb/3.9-core/Dockerfile
+++ b/influxdb/3.9-core/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.9.0
+ENV INFLUXDB_VERSION=3.9.1
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \

--- a/influxdb/3.9-enterprise/Dockerfile
+++ b/influxdb/3.9-enterprise/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.9.0
+ENV INFLUXDB_VERSION=3.9.1
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \


### PR DESCRIPTION
## Summary
- Update `ENV INFLUXDB_VERSION` from 3.9.0 to 3.9.1 in 3.9-core and 3.9-enterprise Dockerfiles