### PR TITLE
chore: update influxdb 1.12 tags to 1.12.4

### DIFF
--- a/influxdb/1.12/Dockerfile
+++ b/influxdb/1.12/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:bookworm-curl
 RUN addgroup --system --gid 1500 influxdb && \
     adduser --system --uid 1500 --ingroup influxdb --home /var/lib/influxdb --shell /bin/false influxdb
 
-ENV INFLUXDB_VERSION=1.12.3
+ENV INFLUXDB_VERSION=1.12.4
 # INFLUXDB_PR is for suffixes like -1
 ENV INFLUXDB_PR=-1
 ENV INFLUXDB_PV=${INFLUXDB_VERSION}${INFLUXDB_PR}

--- a/influxdb/1.12/alpine/Dockerfile
+++ b/influxdb/1.12/alpine/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.21
 RUN apk add --no-cache bash ca-certificates tzdata && \
     update-ca-certificates
 
-ENV INFLUXDB_VERSION=1.12.3
+ENV INFLUXDB_VERSION=1.12.4
 # INFLUXDB_PR is for suffixes like -1
 ENV INFLUXDB_PR=
 ENV INFLUXDB_PV=${INFLUXDB_VERSION}${INFLUXDB_PR}

--- a/influxdb/1.12/data/Dockerfile
+++ b/influxdb/1.12/data/Dockerfile
@@ -1,11 +1,11 @@
 FROM buildpack-deps:bookworm-curl
 
-ENV INFLUXDB_VERSION=1.12.3-c1.12.3
+ENV INFLUXDB_VERSION=1.12.4-c1.12.4
 # INFLUXDB_PR is for suffixes like -1
 ENV INFLUXDB_PR=
 ENV INFLUXDB_PV=${INFLUXDB_VERSION}${INFLUXDB_PR}
 RUN curl -fsSLO "https://dl.influxdata.com/enterprise/releases/influxdb-data_${INFLUXDB_PV}_amd64.deb.asc" \
-         -fssLO "https://dl.influxdata.com/enterprise/releases/influxdb-data_${INFLUXDB_PV}_amd64.deb" && \
+         -fsSLO "https://dl.influxdata.com/enterprise/releases/influxdb-data_${INFLUXDB_PV}_amd64.deb" && \
     # Verify InfluxDB 1.X Enterprise \
     gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys \
         # InfluxData Package Signing Key <support@influxdata.com> \

--- a/influxdb/1.12/data/alpine/Dockerfile
+++ b/influxdb/1.12/data/alpine/Dockerfile
@@ -3,13 +3,13 @@ FROM alpine:3.21
 RUN apk add --no-cache tzdata bash ca-certificates && \
     update-ca-certificates
 
-ENV INFLUXDB_VERSION=1.12.3-c1.12.3
+ENV INFLUXDB_VERSION=1.12.4-c1.12.4
 # INFLUXDB_PR is for suffixes like -1
 ENV INFLUXDB_PR=
-ENV INFLUXDB_PV=${INFLUXDB_VERSION}
+ENV INFLUXDB_PV=${INFLUXDB_VERSION}${INFLUXDB_PR}
 RUN apk add --no-cache --virtual .build-deps curl gnupg tar && \
     curl -fsSLO "https://dl.influxdata.com/enterprise/releases/influxdb-data-${INFLUXDB_PV}_linux_amd64.tar.gz.asc" \
-         -fssLO "https://dl.influxdata.com/enterprise/releases/influxdb-data-${INFLUXDB_PV}_linux_amd64.tar.gz" && \
+         -fsSLO "https://dl.influxdata.com/enterprise/releases/influxdb-data-${INFLUXDB_PV}_linux_amd64.tar.gz" && \
     # Verify InfluxDB 1.X Enterprise \
     gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys \
         # InfluxData Package Signing Key <support@influxdata.com> \

--- a/influxdb/1.12/meta/Dockerfile
+++ b/influxdb/1.12/meta/Dockerfile
@@ -1,11 +1,11 @@
 FROM buildpack-deps:bookworm-curl
 
-ENV INFLUXDB_VERSION=1.12.3-c1.12.3
+ENV INFLUXDB_VERSION=1.12.4-c1.12.4
 # INFLUXDB_PR is for suffixes like -1
 ENV INFLUXDB_PR=
 ENV INFLUXDB_PV=${INFLUXDB_VERSION}${INFLUXDB_PR}
 RUN curl -fsSLO "https://dl.influxdata.com/enterprise/releases/influxdb-meta_${INFLUXDB_PV}_amd64.deb.asc" \
-         -fssLO "https://dl.influxdata.com/enterprise/releases/influxdb-meta_${INFLUXDB_PV}_amd64.deb" && \
+         -fsSLO "https://dl.influxdata.com/enterprise/releases/influxdb-meta_${INFLUXDB_PV}_amd64.deb" && \
     # Verify InfluxDB 1.X Enterprise \
     gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys \
         # InfluxData Package Signing Key <support@influxdata.com> \

--- a/influxdb/1.12/meta/alpine/Dockerfile
+++ b/influxdb/1.12/meta/alpine/Dockerfile
@@ -3,13 +3,13 @@ FROM alpine:3.21
 RUN apk add --no-cache tzdata bash ca-certificates && \
     update-ca-certificates
 
-ENV INFLUXDB_VERSION=1.12.3-c1.12.3
+ENV INFLUXDB_VERSION=1.12.4-c1.12.4
 # INFLUXDB_PR is for suffixes like -1
 ENV INFLUXDB_PR=
 ENV INFLUXDB_PV=${INFLUXDB_VERSION}${INFLUXDB_PR}
 RUN apk add --no-cache --virtual .build-deps curl gnupg tar && \
     curl -fsSLO "https://dl.influxdata.com/enterprise/releases/influxdb-meta-${INFLUXDB_PV}_linux_amd64.tar.gz.asc" \
-         -fssLO "https://dl.influxdata.com/enterprise/releases/influxdb-meta-${INFLUXDB_PV}_linux_amd64.tar.gz" && \
+         -fsSLO "https://dl.influxdata.com/enterprise/releases/influxdb-meta-${INFLUXDB_PV}_linux_amd64.tar.gz" && \
     # Verify InfluxDB 1.X Enterprise \
     gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys \
         # InfluxData Package Signing Key <support@influxdata.com> \


### PR DESCRIPTION
- Update influxdb 1.12 tags to 1.12.4
- Fix some curl commands to use `-fsSLO` instead of `-fssLO`
- Fix 1.12-data-alpine to use INFLUXDB_PR in INFLUXDB_PV. This does not have any impact on the images currently being built.