### PR TITLE
fix: update chronograf(alpine) to copy only binaries from tarball.

### DIFF
--- a/chronograf/1.11/alpine/Dockerfile
+++ b/chronograf/1.11/alpine/Dockerfile
@@ -22,7 +22,7 @@ RUN set -ex && \
     tar -C /usr/src -xzf chronograf-${CHRONOGRAF_VERSION}_linux_amd64.tar.gz && \
     rm -f /usr/src/chronograf-*/chronograf.conf && \
     chmod +x /usr/src/chronograf-*/* && \
-    cp -a /usr/src/chronograf-*/* /usr/bin/ && \
+    cp -a /usr/src/chronograf-*/usr/bin/* /usr/bin && \
     gpgconf --kill all && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \
     apk del .build-deps && \

--- a/chronograf/1.11/alpine/Dockerfile
+++ b/chronograf/1.11/alpine/Dockerfile
@@ -21,7 +21,7 @@ RUN set -ex && \
     mkdir -p /usr/src && \
     tar -C /usr/src -xzf chronograf-${CHRONOGRAF_VERSION}_linux_amd64.tar.gz && \
     rm -f /usr/src/chronograf-*/chronograf.conf && \
-    chmod +x /usr/src/chronograf-*/* && \
+    chmod +x /usr/src/chronograf-*/usr/bin/* && \
     cp -a /usr/src/chronograf-*/usr/bin/* /usr/bin && \
     gpgconf --kill all && \
     rm -rf *.tar.gz* /usr/src /root/.gnupg && \


### PR DESCRIPTION
closes #865 and #866

Since static tarballs are not available for the 1.11.2 release, copy into the docker image only the required binaries.  This should preserve the same internal file structure found in the 1.10.9 release.  