### PR TITLE
chore: update core and enterprise to 3.9.3

### DIFF
--- a/influxdb/3.9-core/Dockerfile
+++ b/influxdb/3.9-core/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.9.2
+ENV INFLUXDB_VERSION=3.9.3
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \

--- a/influxdb/3.9-enterprise/Dockerfile
+++ b/influxdb/3.9-enterprise/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.9.2
+ENV INFLUXDB_VERSION=3.9.3
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \


### PR DESCRIPTION
Bumps `INFLUXDB_VERSION` to **3.9.3** in the v3 core and enterprise Dockerfiles for the 3.9.3 patch release.

- `influxdb/3.9-core/Dockerfile`: 3.9.2 → 3.9.3
- `influxdb/3.9-enterprise/Dockerfile`: 3.9.2 → 3.9.3

Part of the InfluxDB 3 Core/Enterprise 3.9.3 release. Enterprise artifacts are live on dl.influxdata.com; Core artifacts are publishing (build in progress) -- the image build needs both before it goes green.

Follow-up: once this merges, the `docker-library/official-images` manifest will be updated with the merge SHA + 3.9.3 tags.