### PR TITLE
chore: update alpine base to 3.24 in kapacitor and chronograf

### DIFF
--- a/chronograf/1.10/alpine/Dockerfile
+++ b/chronograf/1.10/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22
+FROM alpine:3.24
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates setpriv && \

--- a/chronograf/1.11/alpine/Dockerfile
+++ b/chronograf/1.11/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22
+FROM alpine:3.24
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates setpriv && \

--- a/chronograf/1.6/alpine/Dockerfile
+++ b/chronograf/1.6/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.24
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/chronograf/1.7/alpine/Dockerfile
+++ b/chronograf/1.7/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM alpine:3.24
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/chronograf/1.8/alpine/Dockerfile
+++ b/chronograf/1.8/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM alpine:3.24
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/chronograf/1.9/alpine/Dockerfile
+++ b/chronograf/1.9/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM alpine:3.24
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/kapacitor/1.4/alpine/Dockerfile
+++ b/kapacitor/1.4/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.24
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/kapacitor/1.5/alpine/Dockerfile
+++ b/kapacitor/1.5/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.24
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/kapacitor/1.6/alpine/Dockerfile
+++ b/kapacitor/1.6/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM alpine:3.24
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/kapacitor/1.7/alpine/Dockerfile
+++ b/kapacitor/1.7/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM alpine:3.24
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates su-exec && \

--- a/kapacitor/1.8/alpine/Dockerfile
+++ b/kapacitor/1.8/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23
+FROM alpine:3.24
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates setpriv && \


### PR DESCRIPTION
In alpine Dockerfiles for kapacitor and chronograf, the base image is now set to the 3.24 release. 

Smoke tested each new image locally with
* a local docker build
* run of the built image
* verification of normal startup
* in chronograf checked the UI wizard updated with "Welcome to the latest Chronograf..." message

for example. 
```bash
$ cd ../../1.9/alpine/
$ docker build --tag chronograf:1.9-alpine-local .
$ docker run --name chronograf-1.9-alpine-test -p 8888:8888 chronograf:1.9-alpine-local
# verify application load in browser... 
$ docker rm chronograf-1.9-alpine-test 
$ docker rmi chronograf:1.9-alpine-local 
$ cd ../../1.10/alpine/
```