### PR TITLE
chore: release Chronograf 1.11.4

### DIFF
--- a/chronograf/1.11/Dockerfile
+++ b/chronograf/1.11/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex && \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done
 
-ENV CHRONOGRAF_VERSION 1.11.3
+ENV CHRONOGRAF_VERSION 1.11.4
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     case "${dpkgArch##*-}" in \
       amd64) ARCH='amd64';; \

--- a/chronograf/1.11/alpine/Dockerfile
+++ b/chronograf/1.11/alpine/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:3.22
+FROM alpine:3.24
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates setpriv && \
     update-ca-certificates
 
-ENV CHRONOGRAF_VERSION=1.11.3
+ENV CHRONOGRAF_VERSION=1.11.4
 
 RUN set -ex && \
     mkdir ~/.gnupg; \


### PR DESCRIPTION
Update alpine base to 3.24 - related to https://github.com/influxdata/influxdata-docker/issues/884.

https://github.com/influxdata/chronograf/releases/tag/1.11.4