### PR TITLE
chore: add influxdb3 3.10.0 Dockerfiles

### DIFF
--- a/influxdb/3.10-core/Dockerfile
+++ b/influxdb/3.10-core/Dockerfile
@@ -1,0 +1,57 @@
+FROM ubuntu:24.04
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y \
+        ca-certificates \
+        curl \
+        gettext-base \
+        gnupg \
+        libssl3 && \
+    rm -rf /var/lib/apt/lists*
+
+RUN groupadd --gid 1500 influxdb3 && \
+    useradd  --uid 1500 --gid influxdb3 --shell /bin/bash --create-home influxdb3 && \
+    mkdir -p /var/lib/influxdb3 \
+             /usr/lib/influxdb3 \
+             /plugins
+
+ENV INFLUXDB_VERSION=3.10.0
+RUN case "$(dpkg --print-architecture)" in \
+        amd64) ARCH=amd64 ;; \
+        arm64) ARCH=arm64 ;; \
+        *) echo 'Unsupported Architecture' ; exit 1 ;; \
+    esac && \
+    curl -fsSLO "https://dl.influxdata.com/influxdb/releases/influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
+         -fsSLO "https://dl.influxdata.com/influxdb/releases/influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \
+    # Verify InfluxDB3 Core \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
+        # InfluxData Package Signing Key <support@influxdata.com> \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 && \
+    gpg --batch --verify \
+        "influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
+        "influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \
+    # Install InfluxDB3 Core \
+    tar --strip-components 1 -C /usr/lib/influxdb3 -xvf "influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \
+    mv /usr/lib/influxdb3/influxdb3 /usr/bin/influxdb3 && \
+    chown -R influxdb3:influxdb3 /var/lib/influxdb3 /plugins && \
+    chown -R root:root /usr/lib/influxdb3 && \
+    # Cleanup \
+    rm  "influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
+        "influxdb3-core-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz"
+
+COPY entrypoint.sh /usr/bin/entrypoint.sh
+
+USER influxdb3
+RUN mkdir ~/.influxdb3
+
+ENV INFLUXDB3_PLUGIN_DIR=/plugins
+ENV INFLUXDB3_DATA_DIR=/home/influxdb3/.influxdb3
+ENV INFLUXDB3_SERVE_INVOCATION_METHOD=docker-hub
+ENV INFLUXDB_IOX_DB_DIR=/var/lib/influxdb3
+ENV LOG_FILTER=info
+
+EXPOSE 8181
+
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]
+CMD ["influxdb3", "serve"]

--- a/influxdb/3.10-core/entrypoint.sh
+++ b/influxdb/3.10-core/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+# Unset environment variables; splitting on whitespace
+# Usage: INFLUXDB3_UNSET_VARS="HOST FOO BAR"
+if [[ -n "${INFLUXDB3_UNSET_VARS:-}" ]]; then
+    read -ra vars <<< "${INFLUXDB3_UNSET_VARS}"
+    for var in "${vars[@]}"; do
+        unset "$var" || { echo "Error: Failed to unset variable '$var' (may be readonly)"; exit 1; }
+    done
+fi
+
+args=("${@}")
+
+if [[ "${args[0]:-}" == serve ]] ; then
+    args=(influxdb3 "${args[@]}")
+fi
+
+if [[ "${args[0]:-}" =~ ^- ]] ; then
+    args=(influxdb3 serve "${args[@]}")
+fi
+
+if [[ "${args[0]:-}" == influxdb3 ]] ; then
+    for i in "${!args[@]}"; do
+        args[i]="$(envsubst <<<"${args[i]}")"
+    done
+fi
+
+exec "${args[@]}"

--- a/influxdb/3.10-enterprise/Dockerfile
+++ b/influxdb/3.10-enterprise/Dockerfile
@@ -1,0 +1,57 @@
+FROM ubuntu:24.04
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y \
+        ca-certificates \
+        curl \
+        gettext-base \
+        gnupg \
+        libssl3 && \
+    rm -rf /var/lib/apt/lists*
+
+RUN groupadd --gid 1500 influxdb3 && \
+    useradd  --uid 1500 --gid influxdb3 --shell /bin/bash --create-home influxdb3 && \
+    mkdir -p /var/lib/influxdb3 \
+             /usr/lib/influxdb3 \
+             /plugins
+
+ENV INFLUXDB_VERSION=3.10.0
+RUN case "$(dpkg --print-architecture)" in \
+        amd64) ARCH=amd64 ;; \
+        arm64) ARCH=arm64 ;; \
+        *) echo 'Unsupported Architecture' ; exit 1 ;; \
+    esac && \
+    curl -fsSLO "https://dl.influxdata.com/influxdb/releases/influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
+         -fsSLO "https://dl.influxdata.com/influxdb/releases/influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \
+    # Verify InfluxDB3 Enterprise \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \
+        # InfluxData Package Signing Key <support@influxdata.com> \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 && \
+    gpg --batch --verify \
+        "influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
+        "influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \
+    # Install InfluxDB3 Enterprise \
+    tar --strip-components 1 -C /usr/lib/influxdb3 -xvf "influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz" && \
+    mv /usr/lib/influxdb3/influxdb3 /usr/bin/influxdb3 && \
+    chown -R influxdb3:influxdb3 /var/lib/influxdb3 /plugins && \
+    chown -R root:root /usr/lib/influxdb3 && \
+    # Cleanup \
+    rm  "influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz.asc" \
+        "influxdb3-enterprise-${INFLUXDB_VERSION}_linux_${ARCH}.tar.gz"
+
+COPY entrypoint.sh /usr/bin/entrypoint.sh
+
+USER influxdb3
+RUN mkdir ~/.influxdb3
+
+ENV INFLUXDB3_PLUGIN_DIR=/plugins
+ENV INFLUXDB3_DATA_DIR=/home/influxdb3/.influxdb3
+ENV INFLUXDB3_SERVE_INVOCATION_METHOD=docker-hub
+ENV INFLUXDB_IOX_DB_DIR=/var/lib/influxdb3
+ENV LOG_FILTER=info
+
+EXPOSE 8181
+
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]
+CMD ["influxdb3", "serve"]

--- a/influxdb/3.10-enterprise/entrypoint.sh
+++ b/influxdb/3.10-enterprise/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+# Unset environment variables; splitting on whitespace
+# Usage: INFLUXDB3_UNSET_VARS="HOST FOO BAR"
+if [[ -n "${INFLUXDB3_UNSET_VARS:-}" ]]; then
+    read -ra vars <<< "${INFLUXDB3_UNSET_VARS}"
+    for var in "${vars[@]}"; do
+        unset "$var" || { echo "Error: Failed to unset variable '$var' (may be readonly)"; exit 1; }
+    done
+fi
+
+args=("${@}")
+
+if [[ "${args[0]:-}" == serve ]] ; then
+    args=(influxdb3 "${args[@]}")
+fi
+
+if [[ "${args[0]:-}" =~ ^- ]] ; then
+    args=(influxdb3 serve "${args[@]}")
+fi
+
+if [[ "${args[0]:-}" == influxdb3 ]] ; then
+    for i in "${!args[@]}"; do
+        args[i]="$(envsubst <<<"${args[i]}")"
+    done
+fi
+
+exec "${args[@]}"


### PR DESCRIPTION
## Summary

Add InfluxDB 3 Core and Enterprise `3.10.0` image directories (`influxdb/3.10-core`, `influxdb/3.10-enterprise`), copied from the 3.9 directories with `ENV INFLUXDB_VERSION=3.10.0`.