### PR TITLE
chore: bump influxdb 1.11 alpine images to alpine 3.21

### DIFF
--- a/influxdb/1.11/alpine/Dockerfile
+++ b/influxdb/1.11/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM alpine:3.21
 
 RUN apk add --no-cache \
       bash \

--- a/influxdb/1.11/data/alpine/Dockerfile
+++ b/influxdb/1.11/data/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM alpine:3.21
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \

--- a/influxdb/1.11/meta/alpine/Dockerfile
+++ b/influxdb/1.11/meta/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM alpine:3.21
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache tzdata bash ca-certificates && \


### PR DESCRIPTION
## Summary

Alpine 3.20 reached EOL and was removed from docker-library's supported bases (flagged on docker-library/official-images#21630), failing the manifest check. Bump the three InfluxDB 1.11 alpine images (`1.11/alpine`, `1.11/data/alpine`, `1.11/meta/alpine`) from `alpine:3.20` to `alpine:3.21` — matching the 1.12 alpine images. These images only install stable base packages (bash, ca-certificates, tzdata, curl/wget, gnupg, tar) and extract a prebuilt tarball, so nothing is version-sensitive.