### PR TITLE
feat(telegraf): Add distroless container based on scratch base-image

### DIFF
--- a/telegraf/1.39/distroless/Dockerfile
+++ b/telegraf/1.39/distroless/Dockerfile
@@ -1,0 +1,84 @@
+# Telegraf on scratch: the static (CGO_ENABLED=0) binary plus only the runtime
+# files it needs — no shell, package manager, or OS userland. The alpine stage
+# GPG-verifies the release and assembles the exact final image tree under
+# /rootfs; the scratch stage is a single COPY of it.
+
+ARG TELEGRAF_VERSION=1.39.1
+
+FROM alpine:3.23 AS fetch
+ARG TELEGRAF_VERSION
+
+RUN set -eux; \
+    case "$(apk --print-arch)" in \
+        x86_64)  ARCH='amd64';; \
+        aarch64) ARCH='arm64';; \
+        *) echo "Unsupported architecture: $(apk --print-arch)" >&2; exit 1;; \
+    esac; \
+    apk add --no-cache ca-certificates tzdata wget gnupg tar; \
+    update-ca-certificates; \
+    mkdir -p ~/.gnupg; echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf; \
+    gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 24C975CBA61A024EE1B631787C3D57159FC2F927; \
+    base="telegraf-${TELEGRAF_VERSION}_linux_${ARCH}.tar.gz"; \
+    wget --no-verbose "https://dl.influxdata.com/telegraf/releases/${base}"; \
+    wget --no-verbose "https://dl.influxdata.com/telegraf/releases/${base}.asc"; \
+    gpg --batch --verify "${base}.asc" "${base}"; \
+    mkdir -p /src /rootfs/usr/bin /rootfs/etc/telegraf /rootfs/etc/ssl/certs /rootfs/usr/share; \
+    tar -C /src -xzf "${base}"; \
+    # Copy from the explicit `telegraf-<v>/` prefix: release tar roots vary (some
+    # add a leading ./), which makes a fixed --strip-components unreliable.
+    src="/src/telegraf-${TELEGRAF_VERSION}"; \
+    cp -a "${src}/usr/bin/telegraf"           /rootfs/usr/bin/telegraf; \
+    cp -a "${src}/etc/telegraf/telegraf.conf" /rootfs/etc/telegraf/telegraf.conf; \
+    cp -a "${src}/etc/telegraf/telegraf.d"    /rootfs/etc/telegraf/telegraf.d; \
+    cp /etc/ssl/certs/ca-certificates.crt     /rootfs/etc/ssl/certs/ca-certificates.crt; \
+    cp -a /usr/share/zoneinfo                 /rootfs/usr/share/zoneinfo; \
+    # Resolve hostnames via /etc/hosts before DNS.
+    printf 'hosts: files dns\n' > /rootfs/etc/nsswitch.conf; \
+    # Lets pure-Go os/user (CGO_ENABLED=0) map uid 65532 to a name; without it
+    # lookups like procstat's user tag fail silently. USER below sets the identity.
+    # We run as 65532 (the distroless "nonroot" uid), NOT 65534/nobody: 65534 is the
+    # kernel overflow uid — the id that unmapped user-namespace ids and NFS root-squash
+    # collapse to — so running as it would make telegraf indistinguishable from a
+    # failed-to-map process to security/monitoring tooling. 65532 sits outside that.
+    #   overflow uid default 65534: https://www.kernel.org/doc/html/latest/admin-guide/sysctl/kernel.html
+    #   unmapped userns id -> overflow: https://man7.org/linux/man-pages/man7/user_namespaces.7.html
+    #   distroless nonroot = 65532:     https://github.com/GoogleContainerTools/distroless/blob/main/common/variables.bzl
+    # (nobody is kept in the map so 65534-owned files still resolve; we just never run as it.)
+    printf 'root:x:0:0:root:/root:/sbin/nologin\nnobody:x:65534:65534:nobody:/nonexistent:/sbin/nologin\nnonroot:x:65532:65532:nonroot:/home/nonroot:/sbin/nologin\n' > /rootfs/etc/passwd; \
+    printf 'root:x:0:\nnobody:x:65534:\nnonroot:x:65532:\n' > /rootfs/etc/group; \
+    # $HOME and a writable /tmp for 65532. We set ownership, not mode bits like
+    # 1777: buildah's COPY preserves a dir's ownership but not its mode. Numeric id,
+    # not "nonroot": this chown runs in the alpine stage, whose /etc/passwd has no
+    # nonroot user, so a BusyBox name lookup would fail ("unknown user/group") and
+    # abort under set -eux. A numeric id skips the passwd lookup entirely.
+    #   busybox chown name lookup + err string (xget_uidgid; mirror linked from busybox.net/source.html):
+    #   https://github.com/vda-linux/busybox_mirror/blob/ec0c5cc142f1f9ea57235df5d093fbe180ad9c7d/libpwdgrp/uidgid_get.c#L77-L80
+    mkdir -p /rootfs/home/nonroot /rootfs/tmp; chown 65532:65532 /rootfs/home/nonroot /rootfs/tmp
+
+FROM scratch
+
+ARG TELEGRAF_VERSION
+ENV TELEGRAF_VERSION=${TELEGRAF_VERSION}
+LABEL org.opencontainers.image.title="telegraf" \
+      org.opencontainers.image.description="Distroless Telegraf — static binary on scratch (no shell, no OS userland, non-root)" \
+      org.opencontainers.image.version="${TELEGRAF_VERSION}" \
+      org.opencontainers.image.source="https://github.com/influxdata/influxdata-docker" \
+      org.opencontainers.image.base.name="scratch" \
+      org.opencontainers.image.vendor="InfluxData Inc." \
+      org.opencontainers.image.licenses="MIT"
+
+# The whole rootfs was staged and GPG-verified in the fetch stage; one COPY
+# brings it over. Ownership (incl. the 65532-owned /home/nonroot and /tmp) is
+# preserved by docker, podman, and buildah alike.
+COPY --from=fetch /rootfs/ /
+
+ENV HOME=/home/nonroot
+
+# Numeric, not a name: with runAsNonRoot=true the kubelet reads the image's USER
+# field directly (never its /etc/passwd), so a named user fails admission
+# ("cannot verify user is non-root"). 65532 is the distroless "nonroot" uid.
+# https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kuberuntime/security_context_others.go#L50
+USER 65532:65532
+
+ENTRYPOINT ["/usr/bin/telegraf"]
+CMD ["--config", "/etc/telegraf/telegraf.conf", "--config-directory", "/etc/telegraf/telegraf.d"]

--- a/telegraf/manifest.json
+++ b/telegraf/manifest.json
@@ -22,6 +22,16 @@
         "amd64",
         "arm64v8"
       ]
+    },
+    {
+      "name": "distroless",
+      "versions": [
+        "1.39"
+      ],
+      "architectures": [
+        "amd64",
+        "arm64v8"
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Add a `distroless` Telegraf variant (1.39)

This adds an opt-in `distroless` variant for Telegraf 1.39, producing `telegraf:1.39-distroless`. The image is built **`FROM scratch`** and ships only the static `telegraf` binary plus the handful of files it needs at runtime (no shell, no libc, no package manager, no OS userland), and runs non-root (uid `65532`). The change is purely additive: the existing `default` and `alpine` images are untouched.

## What to review

| File | What changed |
|---|---|
| `telegraf/1.39/distroless/Dockerfile` | **New.** Two-stage build (alpine `fetch` → `scratch`). The heart of the PR. |
| `telegraf/manifest.json` | Registers `distroless` for `1.39` on `amd64` + `arm64v8`. |

`1.39-distroless` maps to Telegraf release **1.39.1** (`ENV TELEGRAF_VERSION 1.39.1`).

> **Scope note:** this revision covers **1.39 only**, and ships **no test scripts** — both per @srebhan's feedback (drop the extra versions; remove the `TESTING.md`/`local-test.sh`/`circle-test.sh` additions to avoid CI credit consumption). If 1.37/1.38 variants are wanted, they're a trivial follow-up (same Dockerfile, different version).

### How the Dockerfile works

It's a two-stage build:

- An **alpine `fetch` stage** downloads the release with `wget`, **GPG-verifies** the tarball against InfluxData's signing key (`24C975CBA61A024EE1B631787C3D57159FC2F927` — the same key the `default` and `alpine` siblings use), unpacks it, and assembles **`/rootfs`** as the exact final image tree (binary + config + CA bundle + tzdata + `nsswitch.conf` + `passwd`/`group` + `home`/`tmp`).
- The final **`scratch` stage** brings that tree over with a single **plain `COPY --from=fetch /rootfs/ /`** — no `ADD --unpack`, no `COPY --parents`, no other BuildKit-only feature — so it isn't tied to any one builder.
- **Integrity** is the `gpg --batch --verify` check in the fetch stage; the build runs under `set -eux` and fails loudly if verification fails. Nothing from alpine reaches the final image except the files explicitly staged under `/rootfs`.
- The runtime base is `scratch`, so there are no OS packages to track or bump.

<details>
<summary><b>What the final image contains</b>: the complete inventory (everything a distro base would add is deliberately omitted)</summary>

| Path | Why it's needed |
|---|---|
| `/usr/bin/telegraf` | the GPG-verified static (`CGO_ENABLED=0`) binary |
| `/etc/telegraf/{telegraf.conf,telegraf.d}` | default config + drop-in dir |
| `/etc/ssl/certs/ca-certificates.crt` | TLS trust roots for outbound HTTPS (e.g. `influxdb_v2`) |
| `/usr/share/zoneinfo` | IANA tz database: `time.LoadLocation`, `json_timezone`, cron schedules |
| `/etc/nsswitch.conf` | `hosts: files dns` so Go's resolver checks `/etc/hosts` before DNS |
| `/etc/passwd`, `/etc/group` | deterministic identities: `root`, `nobody` (65534), `nonroot` (65532) |
| `/home/nonroot` (owned 65532) | `$HOME` for uid 65532 |
| `/tmp` (owned 65532) | `os.TempDir()` default; `scratch` ships neither |

</details>

## Not a drop-in replacement

This is a hardening-focused variant, not a swap-in for the `default`/`alpine` images. Because there is no shell and no `setcap`/`setpriv`, it does **not** support the ICMP `ping` input, privileged ports (below 1024), or shell-out plugins like `exec`, `snmp`, and `sensors`. It targets network-listener and push workloads. The Dockerfile header notes the image ships no shell or OS userland — the root cause of these limitations.

## Why `scratch`, and why a tag not a digest

Most CVEs flagged against the `default`/`alpine` images come from the parent image's userland (distro packages, the shell, coreutils) rather than from Telegraf itself (e.g. [CVE-2026-48962](https://security-tracker.debian.org/tracker/CVE-2026-48962)), which is why we periodically swap between the Debian- and Alpine-based images to stay ahead of scanners. Building `FROM scratch` drops that whole layer, so CVE exposure comes down to the Telegraf binary plus a maintained CA bundle and tzdata. The image also runs non-root, so it satisfies Kubernetes `runAsNonRoot` out of the box.

Two integrity/versioning choices in this revision, per @srebhan's feedback:

- **`FROM scratch`, not a distroless base image.** Rather than depend on `gcr.io/distroless/static`, we assemble the rootfs ourselves in the alpine stage. That gives a complete inventory of the image (see the table above) with nothing we don't use, and one fewer external base to track.
- **Pull by tag/version, not by pinned digest.** The release is selected by `TELEGRAF_VERSION` and GPG-verified; the fetch base is the `alpine:3.23` tag. Neither is `sha256`-pinned. This matches how InfluxData publishes to Docker Hub — a new release is picked up by bumping the version and rebuilding, with no per-release digest to hand-edit. (An earlier revision `sha256`-pinned both the tarball via `ADD --checksum=` **and** a `gcr.io/distroless/static` base, each of which would need a manual digest bump every release.) Integrity is still enforced, now by the GPG signature instead of a committed hash.

**The tradeoff we accept:** we own refreshing the CA bundle and tzdata, both sourced from the `alpine:3.23` fetch base at build time. Because `3.23` is a patch-rolling tag, a plain rebuild picks up alpine's latest CA/tzdata patches within the 3.23 series — so a periodic rebuild keeps the data fresh. Once 3.23 reaches EOL, the fetch base must be bumped to the next series (an explicit part of that accepted cost). One scanning caveat: a `scratch` image exposes no OS-package database, so scanners report zero OS packages — a cleaner report, but the copied CA bundle and tzdata aren't scanner-visible.

## Testing

Built and run locally on `linux/arm64` with Docker (plain build, no `--privileged`). The fetch-stage GPG check gates every build.

- **Build + integrity:** `docker build` succeeds and the fetch stage reports `Good signature from "InfluxData Package Signing Key"`; the build aborts if verification fails.
- **Version:** `telegraf --version` → `Telegraf 1.39.1`.
- **Non-root identity:** the image's `USER` is `65532:65532`, and a `procstat` run (`pid_finder = "native"`, `--test`) emits `user="nonroot"` — i.e. uid 65532 resolves to the `nonroot` name from the image's own `/etc/passwd`.
- **Genuinely shell-less:** no shell or `pgrep` in the image — `procstat`'s default `pgrep` finder errors with `could not find pgrep binary`, and the pure-Go `native` finder is required.
- **Kubernetes `runAsNonRoot`:** in a local `kind` cluster, a pod with `securityContext.runAsNonRoot: true` referencing this image is admitted and runs (`Completed`), confirming the numeric `USER 65532` passes the kubelet's non-root check. (A named `USER` would fail that check — hence numeric.)

**Reproduce locally:**

```bash
cd telegraf/1.39/distroless
docker build -t telegraf:1.39-distroless .   # plain `podman build` works too

docker run --rm telegraf:1.39-distroless --version           # -> Telegraf 1.39.1
docker inspect -f '{{.Config.User}}' telegraf:1.39-distroless # -> 65532:65532
```
