### PR TITLE
chore(chronograf): Bump alpine base-image to supported version

### DIFF
--- a/chronograf/1.10/alpine/Dockerfile
+++ b/chronograf/1.10/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22
+FROM alpine:3.24
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates setpriv && \

--- a/chronograf/1.8/alpine/Dockerfile
+++ b/chronograf/1.8/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM alpine:3.24
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \

--- a/chronograf/1.9/alpine/Dockerfile
+++ b/chronograf/1.9/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM alpine:3.24
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates && \


### PR DESCRIPTION
This PR updates the version of the Alpine base image to a maintained version (see https://github.com/docker-library/official-images/pull/21630#issuecomment-4663497876).

While we are trying to avoid re-tagging images with different content this seems to be a common practice by Docker to incorporate security issues (see https://github.com/docker-library/official-images/pull/21702#issuecomment-4792419997). Therefore, we shouldn't bother and just bump the base-image.