### PR TITLE
chore: 3.10.3 / 3.9.9 version updates for influxdb3 enterprise

### DIFF
--- a/influxdb/3.10-enterprise/Dockerfile
+++ b/influxdb/3.10-enterprise/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.10.2
+ENV INFLUXDB_VERSION=3.10.3
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \

--- a/influxdb/3.9-enterprise/Dockerfile
+++ b/influxdb/3.9-enterprise/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.9.7
+ENV INFLUXDB_VERSION=3.9.9
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \


### PR DESCRIPTION
Bumps the influxdb3 enterprise images to the latest patch releases:

- `influxdb/3.10-enterprise`: 3.10.2 -> 3.10.3
- `influxdb/3.9-enterprise`: 3.9.7 -> 3.9.9

Both enterprise tarballs are published on dl.influxdata.com. Core images are unchanged (no new core tarballs were published for these patches). Follows the same shape as #893.