### PR TITLE
chore(kapacitor): Bump Alpine to 3.24

### DIFF
--- a/kapacitor/1.7/alpine/Dockerfile
+++ b/kapacitor/1.7/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM alpine:3.24
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates su-exec && \

--- a/kapacitor/1.8/alpine/Dockerfile
+++ b/kapacitor/1.8/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23
+FROM alpine:3.24
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
 RUN apk add --no-cache ca-certificates setpriv && \


### PR DESCRIPTION
Update the Alpine base image to 3.24 for the Kapacitor 1.7 and 1.8 Alpine variants.