### PR TITLE
chore(chronograf): Update manifest to updated versions and architectures

### DIFF
--- a/chronograf/manifest.json
+++ b/chronograf/manifest.json
@@ -3,7 +3,7 @@
   "maintainers": [
     "Brandon Pfeifer  <bpfeifer@influxdata.com> (@bnpfeife)"
   ],
-  "versions": ["1.6", "1.7", "1.8", "1.9", "1.10", "1.11"],
+  "versions": ["1.10", "1.11"],
   "architectures": [
     "amd64",
     "arm64v8"

--- a/chronograf/manifest.json
+++ b/chronograf/manifest.json
@@ -6,7 +6,6 @@
   "versions": ["1.6", "1.7", "1.8", "1.9", "1.10", "1.11"],
   "architectures": [
     "amd64",
-    "arm32v7",
     "arm64v8"
   ],
   "variants": [


### PR DESCRIPTION
Chronograf is no longer built for the 32-bit ARMv7 architecture starting with Chronograf v1.11. Therefore, we have to remove this architecture from the manifest.

The PR also removes the EOL versions v1.6, v1.7, v1.8 and v1.9 from the manifest.
resolves #882 