### PR TITLE
fix(telegraf): Correct supplementary group handling when dropping privileges

### DIFF
--- a/telegraf/1.37/alpine/Dockerfile
+++ b/telegraf/1.37/alpine/Dockerfile
@@ -34,7 +34,10 @@ RUN ARCH= && \
     apk del .build-deps && \
     addgroup -S telegraf && \
     adduser -S telegraf -G telegraf && \
-    chown -R telegraf:telegraf /etc/telegraf
+    chown -R telegraf:telegraf /etc/telegraf && \
+    # drop root from the base image default supplementary groups (bin, disk,
+    # video, ...) so they are not granted to container processes at runtime
+    for g in $(id -Gn root); do [ "$g" = 'root' ] || delgroup root "$g"; done
 
 EXPOSE 8125/udp 8092/udp 8094
 

--- a/telegraf/1.37/alpine/entrypoint.sh
+++ b/telegraf/1.37/alpine/entrypoint.sh
@@ -14,18 +14,11 @@ else
     # ensure HOME is set to the telegraf user's home dir
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
 
-    # start from the telegraf user's own groups so memberships baked into
-    # /etc/group are kept (as su-exec's initgroups did), then honor groups
-    # supplied via 'docker run --group-add ...' but drop 'root' and anything
-    # already present
+    # combine the telegraf user's own groups, so memberships baked into
+    # /etc/group are kept (as su-exec's initgroups did), with any supplied via
+    # 'docker run --group-add ...', then drop 'root' and any duplicates
     # see https://github.com/influxdata/influxdata-docker/issues/724
-    groups="$(id -Gn telegraf | tr ' ' ',')"
-    extra_groups="$(id -Gn || true)"
-    for group in $extra_groups; do
-        case ",${groups},root," in
-            *",${group},"*) ;;
-            *) groups="${groups},${group}" ;;
-        esac
-    done
+    groups="$(printf '%s %s' "$(id -Gn telegraf)" "$(id -Gn || true)" \
+        | tr ' ' '\n' | grep -vx root | sort -u | paste -sd, -)"
     exec setpriv --reuid telegraf --regid telegraf --groups "$groups" "$@"
 fi

--- a/telegraf/1.37/alpine/entrypoint.sh
+++ b/telegraf/1.37/alpine/entrypoint.sh
@@ -14,15 +14,17 @@ else
     # ensure HOME is set to the telegraf user's home dir
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
 
-    # honor groups supplied via 'docker run --group-add ...' but drop 'root'
-    # (also removes 'telegraf' since we unconditionally add it and don't want it listed twice)
+    # start from the telegraf user's own groups so memberships baked into
+    # /etc/group are kept (as su-exec's initgroups did), then honor groups
+    # supplied via 'docker run --group-add ...' but drop 'root' and anything
+    # already present
     # see https://github.com/influxdata/influxdata-docker/issues/724
-    groups="telegraf"
+    groups="$(id -Gn telegraf | tr ' ' ',')"
     extra_groups="$(id -Gn || true)"
     for group in $extra_groups; do
-        case "$group" in
-            root | telegraf) ;;
-            *) groups="$groups,$group" ;;
+        case ",${groups},root," in
+            *",${group},"*) ;;
+            *) groups="${groups},${group}" ;;
         esac
     done
     exec setpriv --reuid telegraf --regid telegraf --groups "$groups" "$@"

--- a/telegraf/1.37/entrypoint.sh
+++ b/telegraf/1.37/entrypoint.sh
@@ -14,18 +14,11 @@ else
     # ensure HOME is set to the telegraf user's home dir
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
 
-    # start from the telegraf user's own groups so memberships baked into
-    # /etc/group are kept (as su-exec's initgroups did), then honor groups
-    # supplied via 'docker run --group-add ...' but drop 'root' and anything
-    # already present
+    # combine the telegraf user's own groups, so memberships baked into
+    # /etc/group are kept (as su-exec's initgroups did), with any supplied via
+    # 'docker run --group-add ...', then drop 'root' and any duplicates
     # see https://github.com/influxdata/influxdata-docker/issues/724
-    groups="$(id -Gn telegraf | tr ' ' ',')"
-    extra_groups="$(id -Gn || true)"
-    for group in $extra_groups; do
-        case ",${groups},root," in
-            *",${group},"*) ;;
-            *) groups="${groups},${group}" ;;
-        esac
-    done
+    groups="$(printf '%s %s' "$(id -Gn telegraf)" "$(id -Gn || true)" \
+        | tr ' ' '\n' | grep -vx root | sort -u | paste -sd, -)"
     exec setpriv --reuid telegraf --regid telegraf --groups "$groups" "$@"
 fi

--- a/telegraf/1.37/entrypoint.sh
+++ b/telegraf/1.37/entrypoint.sh
@@ -14,15 +14,17 @@ else
     # ensure HOME is set to the telegraf user's home dir
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
 
-    # honor groups supplied via 'docker run --group-add ...' but drop 'root'
-    # (also removes 'telegraf' since we unconditionally add it and don't want it listed twice)
+    # start from the telegraf user's own groups so memberships baked into
+    # /etc/group are kept (as su-exec's initgroups did), then honor groups
+    # supplied via 'docker run --group-add ...' but drop 'root' and anything
+    # already present
     # see https://github.com/influxdata/influxdata-docker/issues/724
-    groups="telegraf"
+    groups="$(id -Gn telegraf | tr ' ' ',')"
     extra_groups="$(id -Gn || true)"
     for group in $extra_groups; do
-        case "$group" in
-            root | telegraf) ;;
-            *) groups="$groups,$group" ;;
+        case ",${groups},root," in
+            *",${group},"*) ;;
+            *) groups="${groups},${group}" ;;
         esac
     done
     exec setpriv --reuid telegraf --regid telegraf --groups "$groups" "$@"

--- a/telegraf/1.38/alpine/Dockerfile
+++ b/telegraf/1.38/alpine/Dockerfile
@@ -34,7 +34,10 @@ RUN ARCH= && \
     apk del .build-deps && \
     addgroup -S telegraf && \
     adduser -S telegraf -G telegraf && \
-    chown -R telegraf:telegraf /etc/telegraf
+    chown -R telegraf:telegraf /etc/telegraf && \
+    # drop root from the base image default supplementary groups (bin, disk,
+    # video, ...) so they are not granted to container processes at runtime
+    for g in $(id -Gn root); do [ "$g" = 'root' ] || delgroup root "$g"; done
 
 EXPOSE 8125/udp 8092/udp 8094
 

--- a/telegraf/1.38/alpine/entrypoint.sh
+++ b/telegraf/1.38/alpine/entrypoint.sh
@@ -14,18 +14,11 @@ else
     # ensure HOME is set to the telegraf user's home dir
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
 
-    # start from the telegraf user's own groups so memberships baked into
-    # /etc/group are kept (as su-exec's initgroups did), then honor groups
-    # supplied via 'docker run --group-add ...' but drop 'root' and anything
-    # already present
+    # combine the telegraf user's own groups, so memberships baked into
+    # /etc/group are kept (as su-exec's initgroups did), with any supplied via
+    # 'docker run --group-add ...', then drop 'root' and any duplicates
     # see https://github.com/influxdata/influxdata-docker/issues/724
-    groups="$(id -Gn telegraf | tr ' ' ',')"
-    extra_groups="$(id -Gn || true)"
-    for group in $extra_groups; do
-        case ",${groups},root," in
-            *",${group},"*) ;;
-            *) groups="${groups},${group}" ;;
-        esac
-    done
+    groups="$(printf '%s %s' "$(id -Gn telegraf)" "$(id -Gn || true)" \
+        | tr ' ' '\n' | grep -vx root | sort -u | paste -sd, -)"
     exec setpriv --reuid telegraf --regid telegraf --groups "$groups" "$@"
 fi

--- a/telegraf/1.38/alpine/entrypoint.sh
+++ b/telegraf/1.38/alpine/entrypoint.sh
@@ -14,15 +14,17 @@ else
     # ensure HOME is set to the telegraf user's home dir
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
 
-    # honor groups supplied via 'docker run --group-add ...' but drop 'root'
-    # (also removes 'telegraf' since we unconditionally add it and don't want it listed twice)
+    # start from the telegraf user's own groups so memberships baked into
+    # /etc/group are kept (as su-exec's initgroups did), then honor groups
+    # supplied via 'docker run --group-add ...' but drop 'root' and anything
+    # already present
     # see https://github.com/influxdata/influxdata-docker/issues/724
-    groups="telegraf"
+    groups="$(id -Gn telegraf | tr ' ' ',')"
     extra_groups="$(id -Gn || true)"
     for group in $extra_groups; do
-        case "$group" in
-            root | telegraf) ;;
-            *) groups="$groups,$group" ;;
+        case ",${groups},root," in
+            *",${group},"*) ;;
+            *) groups="${groups},${group}" ;;
         esac
     done
     exec setpriv --reuid telegraf --regid telegraf --groups "$groups" "$@"

--- a/telegraf/1.38/entrypoint.sh
+++ b/telegraf/1.38/entrypoint.sh
@@ -14,18 +14,11 @@ else
     # ensure HOME is set to the telegraf user's home dir
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
 
-    # start from the telegraf user's own groups so memberships baked into
-    # /etc/group are kept (as su-exec's initgroups did), then honor groups
-    # supplied via 'docker run --group-add ...' but drop 'root' and anything
-    # already present
+    # combine the telegraf user's own groups, so memberships baked into
+    # /etc/group are kept (as su-exec's initgroups did), with any supplied via
+    # 'docker run --group-add ...', then drop 'root' and any duplicates
     # see https://github.com/influxdata/influxdata-docker/issues/724
-    groups="$(id -Gn telegraf | tr ' ' ',')"
-    extra_groups="$(id -Gn || true)"
-    for group in $extra_groups; do
-        case ",${groups},root," in
-            *",${group},"*) ;;
-            *) groups="${groups},${group}" ;;
-        esac
-    done
+    groups="$(printf '%s %s' "$(id -Gn telegraf)" "$(id -Gn || true)" \
+        | tr ' ' '\n' | grep -vx root | sort -u | paste -sd, -)"
     exec setpriv --reuid telegraf --regid telegraf --groups "$groups" "$@"
 fi

--- a/telegraf/1.38/entrypoint.sh
+++ b/telegraf/1.38/entrypoint.sh
@@ -14,15 +14,17 @@ else
     # ensure HOME is set to the telegraf user's home dir
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
 
-    # honor groups supplied via 'docker run --group-add ...' but drop 'root'
-    # (also removes 'telegraf' since we unconditionally add it and don't want it listed twice)
+    # start from the telegraf user's own groups so memberships baked into
+    # /etc/group are kept (as su-exec's initgroups did), then honor groups
+    # supplied via 'docker run --group-add ...' but drop 'root' and anything
+    # already present
     # see https://github.com/influxdata/influxdata-docker/issues/724
-    groups="telegraf"
+    groups="$(id -Gn telegraf | tr ' ' ',')"
     extra_groups="$(id -Gn || true)"
     for group in $extra_groups; do
-        case "$group" in
-            root | telegraf) ;;
-            *) groups="$groups,$group" ;;
+        case ",${groups},root," in
+            *",${group},"*) ;;
+            *) groups="${groups},${group}" ;;
         esac
     done
     exec setpriv --reuid telegraf --regid telegraf --groups "$groups" "$@"

--- a/telegraf/1.39/alpine/Dockerfile
+++ b/telegraf/1.39/alpine/Dockerfile
@@ -34,7 +34,10 @@ RUN ARCH= && \
     apk del .build-deps && \
     addgroup -S telegraf && \
     adduser -S telegraf -G telegraf && \
-    chown -R telegraf:telegraf /etc/telegraf
+    chown -R telegraf:telegraf /etc/telegraf && \
+    # drop root from the base image default supplementary groups (bin, disk,
+    # video, ...) so they are not granted to container processes at runtime
+    for g in $(id -Gn root); do [ "$g" = 'root' ] || delgroup root "$g"; done
 
 EXPOSE 8125/udp 8092/udp 8094
 

--- a/telegraf/1.39/alpine/entrypoint.sh
+++ b/telegraf/1.39/alpine/entrypoint.sh
@@ -14,18 +14,11 @@ else
     # ensure HOME is set to the telegraf user's home dir
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
 
-    # start from the telegraf user's own groups so memberships baked into
-    # /etc/group are kept (as su-exec's initgroups did), then honor groups
-    # supplied via 'docker run --group-add ...' but drop 'root' and anything
-    # already present
+    # combine the telegraf user's own groups, so memberships baked into
+    # /etc/group are kept (as su-exec's initgroups did), with any supplied via
+    # 'docker run --group-add ...', then drop 'root' and any duplicates
     # see https://github.com/influxdata/influxdata-docker/issues/724
-    groups="$(id -Gn telegraf | tr ' ' ',')"
-    extra_groups="$(id -Gn || true)"
-    for group in $extra_groups; do
-        case ",${groups},root," in
-            *",${group},"*) ;;
-            *) groups="${groups},${group}" ;;
-        esac
-    done
+    groups="$(printf '%s %s' "$(id -Gn telegraf)" "$(id -Gn || true)" \
+        | tr ' ' '\n' | grep -vx root | sort -u | paste -sd, -)"
     exec setpriv --reuid telegraf --regid telegraf --groups "$groups" "$@"
 fi

--- a/telegraf/1.39/alpine/entrypoint.sh
+++ b/telegraf/1.39/alpine/entrypoint.sh
@@ -14,15 +14,17 @@ else
     # ensure HOME is set to the telegraf user's home dir
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
 
-    # honor groups supplied via 'docker run --group-add ...' but drop 'root'
-    # (also removes 'telegraf' since we unconditionally add it and don't want it listed twice)
+    # start from the telegraf user's own groups so memberships baked into
+    # /etc/group are kept (as su-exec's initgroups did), then honor groups
+    # supplied via 'docker run --group-add ...' but drop 'root' and anything
+    # already present
     # see https://github.com/influxdata/influxdata-docker/issues/724
-    groups="telegraf"
+    groups="$(id -Gn telegraf | tr ' ' ',')"
     extra_groups="$(id -Gn || true)"
     for group in $extra_groups; do
-        case "$group" in
-            root | telegraf) ;;
-            *) groups="$groups,$group" ;;
+        case ",${groups},root," in
+            *",${group},"*) ;;
+            *) groups="${groups},${group}" ;;
         esac
     done
     exec setpriv --reuid telegraf --regid telegraf --groups "$groups" "$@"

--- a/telegraf/1.39/entrypoint.sh
+++ b/telegraf/1.39/entrypoint.sh
@@ -14,18 +14,11 @@ else
     # ensure HOME is set to the telegraf user's home dir
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
 
-    # start from the telegraf user's own groups so memberships baked into
-    # /etc/group are kept (as su-exec's initgroups did), then honor groups
-    # supplied via 'docker run --group-add ...' but drop 'root' and anything
-    # already present
+    # combine the telegraf user's own groups, so memberships baked into
+    # /etc/group are kept (as su-exec's initgroups did), with any supplied via
+    # 'docker run --group-add ...', then drop 'root' and any duplicates
     # see https://github.com/influxdata/influxdata-docker/issues/724
-    groups="$(id -Gn telegraf | tr ' ' ',')"
-    extra_groups="$(id -Gn || true)"
-    for group in $extra_groups; do
-        case ",${groups},root," in
-            *",${group},"*) ;;
-            *) groups="${groups},${group}" ;;
-        esac
-    done
+    groups="$(printf '%s %s' "$(id -Gn telegraf)" "$(id -Gn || true)" \
+        | tr ' ' '\n' | grep -vx root | sort -u | paste -sd, -)"
     exec setpriv --reuid telegraf --regid telegraf --groups "$groups" "$@"
 fi

--- a/telegraf/1.39/entrypoint.sh
+++ b/telegraf/1.39/entrypoint.sh
@@ -14,15 +14,17 @@ else
     # ensure HOME is set to the telegraf user's home dir
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
 
-    # honor groups supplied via 'docker run --group-add ...' but drop 'root'
-    # (also removes 'telegraf' since we unconditionally add it and don't want it listed twice)
+    # start from the telegraf user's own groups so memberships baked into
+    # /etc/group are kept (as su-exec's initgroups did), then honor groups
+    # supplied via 'docker run --group-add ...' but drop 'root' and anything
+    # already present
     # see https://github.com/influxdata/influxdata-docker/issues/724
-    groups="telegraf"
+    groups="$(id -Gn telegraf | tr ' ' ',')"
     extra_groups="$(id -Gn || true)"
     for group in $extra_groups; do
-        case "$group" in
-            root | telegraf) ;;
-            *) groups="$groups,$group" ;;
+        case ",${groups},root," in
+            *",${group},"*) ;;
+            *) groups="${groups},${group}" ;;
         esac
     done
     exec setpriv --reuid telegraf --regid telegraf --groups "$groups" "$@"

--- a/telegraf/nightly/alpine/Dockerfile
+++ b/telegraf/nightly/alpine/Dockerfile
@@ -24,7 +24,10 @@ RUN ARCH= && \
     apk del .build-deps && \
     addgroup -S telegraf && \
     adduser -S telegraf -G telegraf && \
-    chown -R telegraf:telegraf /etc/telegraf
+    chown -R telegraf:telegraf /etc/telegraf && \
+    # drop root from the base image default supplementary groups (bin, disk,
+    # video, ...) so they are not granted to container processes at runtime
+    for g in $(id -Gn root); do [ "$g" = 'root' ] || delgroup root "$g"; done
 
 EXPOSE 8125/udp 8092/udp 8094
 

--- a/telegraf/nightly/alpine/entrypoint.sh
+++ b/telegraf/nightly/alpine/entrypoint.sh
@@ -14,18 +14,11 @@ else
     # ensure HOME is set to the telegraf user's home dir
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
 
-    # start from the telegraf user's own groups so memberships baked into
-    # /etc/group are kept (as su-exec's initgroups did), then honor groups
-    # supplied via 'docker run --group-add ...' but drop 'root' and anything
-    # already present
+    # combine the telegraf user's own groups, so memberships baked into
+    # /etc/group are kept (as su-exec's initgroups did), with any supplied via
+    # 'docker run --group-add ...', then drop 'root' and any duplicates
     # see https://github.com/influxdata/influxdata-docker/issues/724
-    groups="$(id -Gn telegraf | tr ' ' ',')"
-    extra_groups="$(id -Gn || true)"
-    for group in $extra_groups; do
-        case ",${groups},root," in
-            *",${group},"*) ;;
-            *) groups="${groups},${group}" ;;
-        esac
-    done
+    groups="$(printf '%s %s' "$(id -Gn telegraf)" "$(id -Gn || true)" \
+        | tr ' ' '\n' | grep -vx root | sort -u | paste -sd, -)"
     exec setpriv --reuid telegraf --regid telegraf --groups "$groups" "$@"
 fi

--- a/telegraf/nightly/alpine/entrypoint.sh
+++ b/telegraf/nightly/alpine/entrypoint.sh
@@ -14,15 +14,17 @@ else
     # ensure HOME is set to the telegraf user's home dir
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
 
-    # honor groups supplied via 'docker run --group-add ...' but drop 'root'
-    # (also removes 'telegraf' since we unconditionally add it and don't want it listed twice)
+    # start from the telegraf user's own groups so memberships baked into
+    # /etc/group are kept (as su-exec's initgroups did), then honor groups
+    # supplied via 'docker run --group-add ...' but drop 'root' and anything
+    # already present
     # see https://github.com/influxdata/influxdata-docker/issues/724
-    groups="telegraf"
+    groups="$(id -Gn telegraf | tr ' ' ',')"
     extra_groups="$(id -Gn || true)"
     for group in $extra_groups; do
-        case "$group" in
-            root | telegraf) ;;
-            *) groups="$groups,$group" ;;
+        case ",${groups},root," in
+            *",${group},"*) ;;
+            *) groups="${groups},${group}" ;;
         esac
     done
     exec setpriv --reuid telegraf --regid telegraf --groups "$groups" "$@"

--- a/telegraf/nightly/entrypoint.sh
+++ b/telegraf/nightly/entrypoint.sh
@@ -14,18 +14,11 @@ else
     # ensure HOME is set to the telegraf user's home dir
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
 
-    # start from the telegraf user's own groups so memberships baked into
-    # /etc/group are kept (as su-exec's initgroups did), then honor groups
-    # supplied via 'docker run --group-add ...' but drop 'root' and anything
-    # already present
+    # combine the telegraf user's own groups, so memberships baked into
+    # /etc/group are kept (as su-exec's initgroups did), with any supplied via
+    # 'docker run --group-add ...', then drop 'root' and any duplicates
     # see https://github.com/influxdata/influxdata-docker/issues/724
-    groups="$(id -Gn telegraf | tr ' ' ',')"
-    extra_groups="$(id -Gn || true)"
-    for group in $extra_groups; do
-        case ",${groups},root," in
-            *",${group},"*) ;;
-            *) groups="${groups},${group}" ;;
-        esac
-    done
+    groups="$(printf '%s %s' "$(id -Gn telegraf)" "$(id -Gn || true)" \
+        | tr ' ' '\n' | grep -vx root | sort -u | paste -sd, -)"
     exec setpriv --reuid telegraf --regid telegraf --groups "$groups" "$@"
 fi

--- a/telegraf/nightly/entrypoint.sh
+++ b/telegraf/nightly/entrypoint.sh
@@ -14,15 +14,17 @@ else
     # ensure HOME is set to the telegraf user's home dir
     export HOME=$(getent passwd telegraf | cut -d : -f 6)
 
-    # honor groups supplied via 'docker run --group-add ...' but drop 'root'
-    # (also removes 'telegraf' since we unconditionally add it and don't want it listed twice)
+    # start from the telegraf user's own groups so memberships baked into
+    # /etc/group are kept (as su-exec's initgroups did), then honor groups
+    # supplied via 'docker run --group-add ...' but drop 'root' and anything
+    # already present
     # see https://github.com/influxdata/influxdata-docker/issues/724
-    groups="telegraf"
+    groups="$(id -Gn telegraf | tr ' ' ',')"
     extra_groups="$(id -Gn || true)"
     for group in $extra_groups; do
-        case "$group" in
-            root | telegraf) ;;
-            *) groups="$groups,$group" ;;
+        case ",${groups},root," in
+            *",${group},"*) ;;
+            *) groups="${groups},${group}" ;;
         esac
     done
     exec setpriv --reuid telegraf --regid telegraf --groups "$groups" "$@"


### PR DESCRIPTION
Follow-up to #861 and the question raised in #724.

Two issues with the su-exec to setpriv migration:

1. **Alpine images leak root's baked-in groups to telegraf.** The Alpine base image puts root in `bin daemon sys adm disk wheel floppy dialout tape video`, and the entrypoint loop forwards them all:
   ```
   $ docker run --rm telegraf:1.39-alpine id -Gn
   telegraf bin daemon sys adm disk wheel floppy dialout tape video
   ```
   Under su-exec this was `telegraf` only. Fixed at build time by dropping root from those groups, which keeps an intentional `--group-add video` working. Debian images are unaffected.

2. **`setpriv --groups` replaces the supplementary set, dropping the telegraf user's own `/etc/group` memberships** (su-exec used `getgrouplist()`). Entrypoints now seed the list from `id -Gn telegraf`, so derived images that add telegraf to a group keep that membership.

Verified on a patched 1.39/alpine build and the Debian entrypoint: default run yields `telegraf` only; `--group-add` (numeric and named) and baked memberships are preserved; non-root passthrough unchanged.

Now that #861 is merged, `telegraf/nightly/alpine` is included and carries the identical entrypoint.