### PR TITLE
chore: 3.10.3 version update for influxdb3 core

### DIFF
--- a/influxdb/3.10-core/Dockerfile
+++ b/influxdb/3.10-core/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.10.1
+ENV INFLUXDB_VERSION=3.10.3
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \


### PR DESCRIPTION
Bumps the `3.10-core` image to **3.10.3**, mirroring the enterprise bump (#895) for the core side.

Core 3.10.3 is published on dl.influxdata.com -- tarballs, `.asc` signatures, and `.sha256` checksums are all present (linux amd64/arm64), so the Docker build's download + GPG verify will succeed.

This adds the `influxdb:3.10.3-core` tag and advances the moving `core` / `3-core` / `3.10-core` tags (currently still on 3.10.1) once the `docker-library/official-images` manifest PR lands off this change.