### PR TITLE
feat(telegraf): Add tini to image

### DIFF
--- a/telegraf/1.39/Dockerfile
+++ b/telegraf/1.39/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:bookworm-curl
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors libcap2-bin && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors libcap2-bin tini && \
     rm -rf /var/lib/apt/lists/*
 
 RUN set -ex && \
@@ -31,5 +31,5 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
 EXPOSE 8125/udp 8092/udp 8094
 
 COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/entrypoint.sh"]
 CMD ["telegraf"]

--- a/telegraf/1.39/Dockerfile
+++ b/telegraf/1.39/Dockerfile
@@ -31,5 +31,5 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
 EXPOSE 8125/udp 8092/udp 8094
 
 COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint.sh"]
 CMD ["telegraf"]

--- a/telegraf/1.39/alpine/Dockerfile
+++ b/telegraf/1.39/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.23
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata setpriv libcap && \
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata setpriv libcap tini && \
     update-ca-certificates
 
 ENV TELEGRAF_VERSION 1.39.1
@@ -39,5 +39,5 @@ RUN ARCH= && \
 EXPOSE 8125/udp 8092/udp 8094
 
 COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "-g", "--", "/entrypoint.sh"]
 CMD ["telegraf"]

--- a/telegraf/1.39/alpine/Dockerfile
+++ b/telegraf/1.39/alpine/Dockerfile
@@ -39,5 +39,5 @@ RUN ARCH= && \
 EXPOSE 8125/udp 8092/udp 8094
 
 COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/sbin/tini", "-g", "--", "/entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]
 CMD ["telegraf"]

--- a/telegraf/nightly/Dockerfile
+++ b/telegraf/nightly/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:bookworm-curl
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors libcap2-bin && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors libcap2-bin tini && \
     rm -rf /var/lib/apt/lists/*
 
 ENV TELEGRAF_VERSION nightly
@@ -20,5 +20,5 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
 EXPOSE 8125/udp 8092/udp 8094
 
 COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint.sh"]
 CMD ["telegraf"]

--- a/telegraf/nightly/alpine/Dockerfile
+++ b/telegraf/nightly/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3
 
 RUN echo 'hosts: files dns' >> /etc/nsswitch.conf
-RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata setpriv libcap && \
+RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors tzdata setpriv libcap tini && \
     update-ca-certificates
 
 ENV TELEGRAF_VERSION nightly
@@ -29,5 +29,5 @@ RUN ARCH= && \
 EXPOSE 8125/udp 8092/udp 8094
 
 COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]
 CMD ["telegraf"]


### PR DESCRIPTION
An init process will guard against zombie process issues, using tini is the standard approach for containers. This fixes https://github.com/influxdata/influxdata-docker/issues/479.

If the exec plugin is used, it's possible to get a ton of zombie processes if the exec scripts get stuck for whatever reason. 

Design decisions:
* The -g option: Ensures the entire zombie process tree gets killed, far more robust that way
* Why not use the built-in tini (docker run --init): Not all container runtimes support this, this ensures there's a safe default. --init is not supported in most k8s setups.