### PR TITLE
chore: 3.10.4 / 3.9.10 version updates for influxdb3 enterprise

### DIFF
--- a/influxdb/3.10-enterprise/Dockerfile
+++ b/influxdb/3.10-enterprise/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.10.3
+ENV INFLUXDB_VERSION=3.10.4
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \

--- a/influxdb/3.9-enterprise/Dockerfile
+++ b/influxdb/3.9-enterprise/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.9.9
+ENV INFLUXDB_VERSION=3.9.10
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \


### PR DESCRIPTION
Bumps the InfluxDB 3 enterprise images to the latest patch releases:

- `3-enterprise`, `3.10-enterprise`, `3.10.4-enterprise`, `enterprise`: 3.10.3 -> 3.10.4
- `3.9-enterprise`, `3.9.10-enterprise`: 3.9.9 -> 3.9.10

These are the releases carrying the EAR#6946 compactor fix. Their artifacts (tarballs, `.asc` signatures, `.sha256` checksums) are published on dl.influxdata.com for linux amd64/arm64, so the Docker build's download + GPG verify will succeed. Mirrors the previous enterprise bump #895.