### PR TITLE
chore: 3.9.11 / 3.10.5 version updates for influxdb3 core

### DIFF
--- a/influxdb/3.10-core/Dockerfile
+++ b/influxdb/3.10-core/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.10.3
+ENV INFLUXDB_VERSION=3.10.5
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \

--- a/influxdb/3.9-core/Dockerfile
+++ b/influxdb/3.9-core/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.9.6
+ENV INFLUXDB_VERSION=3.9.11
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \


### PR DESCRIPTION
Bumps the influxdb3 core images to the latest patch releases:

- `3.9-core`: 3.9.6 -> 3.9.11
- `3.10-core`: 3.10.3 -> 3.10.5

Both are published to dl.influxdata.com (tarballs + detached signatures verified via `just verify-version`). A follow-up PR to docker-library/official-images will add the corresponding manifest tags once this merges.