### PR TITLE
chore: 3.9.11 / 3.10.5 version updates for influxdb3 enterprise

### DIFF
--- a/influxdb/3.10-enterprise/Dockerfile
+++ b/influxdb/3.10-enterprise/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.10.4
+ENV INFLUXDB_VERSION=3.10.5
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \

--- a/influxdb/3.9-enterprise/Dockerfile
+++ b/influxdb/3.9-enterprise/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.9.10
+ENV INFLUXDB_VERSION=3.9.11
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \


### PR DESCRIPTION
Bumps the influxdb3 enterprise images to the latest patch releases:

- `3.9-enterprise`: 3.9.10 -> 3.9.11
- `3.10-enterprise`: 3.10.3 -> 3.10.5

Follows #907 (which landed 3.9.10 / 3.10.4). Tarballs + detached signatures for both are published on dl.influxdata.com and verified via `just verify-version`.