### PR TITLE
chore: 3.11.1 version updates for influxdb3 core and enterprise

### DIFF
--- a/influxdb/3.11-core/Dockerfile
+++ b/influxdb/3.11-core/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.11.0
+ENV INFLUXDB_VERSION=3.11.1
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \

--- a/influxdb/3.11-enterprise/Dockerfile
+++ b/influxdb/3.11-enterprise/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.11.0
+ENV INFLUXDB_VERSION=3.11.1
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \


### PR DESCRIPTION
Bumps `INFLUXDB_VERSION` to `3.11.1` in `influxdb/3.11-core` and `influxdb/3.11-enterprise`.

Same shape as the 3.10.5 update in #909.

Artifacts and detached GPG signatures are published for every architecture the Dockerfiles fetch, all confirmed returning 200:

- `influxdb3-core-3.11.1_linux_{amd64,arm64}.tar.gz{,.asc}`
- `influxdb3-enterprise-3.11.1_linux_{amd64,arm64}.tar.gz{,.asc}`

Opened from a fork - I do not have write access to this repo.