### PR TITLE
chore: update influxdb3 3.11 images to 3.11.2

### DIFF
--- a/influxdb/3.11-core/Dockerfile
+++ b/influxdb/3.11-core/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.11.1
+ENV INFLUXDB_VERSION=3.11.2
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \

--- a/influxdb/3.11-enterprise/Dockerfile
+++ b/influxdb/3.11-enterprise/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.11.1
+ENV INFLUXDB_VERSION=3.11.2
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \


### PR DESCRIPTION
## Summary

Bumps `INFLUXDB_VERSION` from 3.11.1 to 3.11.2 in the `3.11-core` and `3.11-enterprise` Dockerfiles, following the 3.11.2 release.

Only line 19 changes in each file; every other reference goes through the variable.

Verified the artifacts the build fetches are published for both architectures — `influxdb3-{core,enterprise}-3.11.2_linux_{amd64,arm64}.tar.gz` and their `.asc` signatures all return 200 from dl.influxdata.com.

A follow-up PR against `docker-library/official-images` is still needed to pick this up on Docker Hub, updating `GitCommit` to the resulting `master` commit here.