### PR TITLE
chore: add data and meta node builds for 1.13.0 (1.13)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,8 @@ workflows:
                 - "influxdb/1.11/meta"
                 - "influxdb/1.12/data"
                 - "influxdb/1.12/meta"
+                - "influxdb/1.13/data"
+                - "influxdb/1.13/meta"
 
 jobs:
   build:

--- a/influxdb/1.13/data/Dockerfile
+++ b/influxdb/1.13/data/Dockerfile
@@ -1,0 +1,35 @@
+FROM buildpack-deps:bookworm-curl
+
+ENV INFLUXDB_VERSION=1.13.0-c1.13.0
+# INFLUXDB_PR is for suffixes like -1
+ENV INFLUXDB_PR=
+ENV INFLUXDB_PV=${INFLUXDB_VERSION}${INFLUXDB_PR}
+RUN curl -fsSLO "https://dl.influxdata.com/enterprise/releases/influxdb-data_${INFLUXDB_PV}_amd64.deb.asc" \
+         -fsSLO "https://dl.influxdata.com/enterprise/releases/influxdb-data_${INFLUXDB_PV}_amd64.deb" && \
+    # Verify InfluxDB 1.X Enterprise \
+    gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys \
+        # InfluxData Package Signing Key <support@influxdata.com> \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 && \
+    gpg --batch --verify \
+        "influxdb-data_${INFLUXDB_PV}_amd64.deb.asc" \
+        "influxdb-data_${INFLUXDB_PV}_amd64.deb" && \
+    # Install InfluxDB 1.X Enterprise \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y \
+        "/influxdb-data_${INFLUXDB_PV}_amd64.deb" && \
+    # Cleanup \
+    rm -r "influxdb-data_${INFLUXDB_PV}_amd64.deb.asc" \
+          "influxdb-data_${INFLUXDB_PV}_amd64.deb" \
+          /var/lib/apt/lists/*
+
+COPY influxdb.conf /etc/influxdb/influxdb.conf
+
+EXPOSE 8086
+
+VOLUME /var/lib/influxdb
+
+COPY entrypoint.sh /entrypoint.sh
+COPY init-influxdb.sh /init-influxdb.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["influxd"]

--- a/influxdb/1.13/data/alpine/Dockerfile
+++ b/influxdb/1.13/data/alpine/Dockerfile
@@ -1,0 +1,40 @@
+FROM alpine:3.21
+
+RUN apk add --no-cache tzdata bash ca-certificates && \
+    update-ca-certificates
+
+ENV INFLUXDB_VERSION=1.13.0-c1.13.0
+# INFLUXDB_PR is for suffixes like -1
+ENV INFLUXDB_PR=
+ENV INFLUXDB_PV=${INFLUXDB_VERSION}${INFLUXDB_PR}
+RUN apk add --no-cache --virtual .build-deps curl gnupg tar && \
+    curl -fsSLO "https://dl.influxdata.com/enterprise/releases/influxdb-data-${INFLUXDB_PV}_linux_amd64.tar.gz.asc" \
+         -fsSLO "https://dl.influxdata.com/enterprise/releases/influxdb-data-${INFLUXDB_PV}_linux_amd64.tar.gz" && \
+    # Verify InfluxDB 1.X Enterprise \
+    gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys \
+        # InfluxData Package Signing Key <support@influxdata.com> \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 && \
+    gpg --batch --verify \
+        "influxdb-data-${INFLUXDB_PV}_linux_amd64.tar.gz.asc" \
+        "influxdb-data-${INFLUXDB_PV}_linux_amd64.tar.gz" && \
+    # Install InfluxDB 1.X Enterprise \
+    tar -xvf "influxdb-data-${INFLUXDB_PV}_linux_amd64.tar.gz" \
+        -C /usr/bin --strip-components 1 --wildcards \
+            'influxdb-*/influx' \
+            'influxdb-*/influx_inspect' \
+            'influxdb-*/influxd' && \
+    # Cleanup \
+    rm "influxdb-data-${INFLUXDB_PV}_linux_amd64.tar.gz.asc" \
+       "influxdb-data-${INFLUXDB_PV}_linux_amd64.tar.gz" && \
+    apk del .build-deps
+
+COPY influxdb.conf /etc/influxdb/influxdb.conf
+
+EXPOSE 8086
+
+VOLUME /var/lib/influxdb
+
+COPY entrypoint.sh /entrypoint.sh
+COPY init-influxdb.sh /init-influxdb.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["influxd"]

--- a/influxdb/1.13/data/alpine/entrypoint.sh
+++ b/influxdb/1.13/data/alpine/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+export INFLUXDB_HOSTNAME=${INFLUXDB_HOSTNAME:-$HOSTNAME}
+
+if [ "${1:0:1}" = '-' ]; then
+    set -- influxd "$@"
+fi
+
+if [ "$1" = 'influxd' ]; then
+	/init-influxdb.sh "${@:2}"
+fi
+
+exec "$@"

--- a/influxdb/1.13/data/alpine/influxdb.conf
+++ b/influxdb/1.13/data/alpine/influxdb.conf
@@ -1,0 +1,10 @@
+[meta]
+  dir = "/var/lib/influxdb/meta"
+
+[data]
+  dir = "/var/lib/influxdb/data"
+  engine = "tsm1"
+  wal-dir = "/var/lib/influxdb/wal"
+
+[hinted-handoff]
+  dir = "/var/lib/influxdb/hh"

--- a/influxdb/1.13/data/alpine/init-influxdb.sh
+++ b/influxdb/1.13/data/alpine/init-influxdb.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+set -e
+
+AUTH_ENABLED="$INFLUXDB_HTTP_AUTH_ENABLED"
+
+if [ -z "$AUTH_ENABLED" ]; then
+	AUTH_ENABLED="$(grep -iE '^\s*auth-enabled\s*=\s*true' /etc/influxdb/influxdb.conf | grep -io 'true' | cat)"
+else
+	AUTH_ENABLED="$(echo "$INFLUXDB_HTTP_AUTH_ENABLED" | grep -io 'true' | cat)"
+fi
+
+INIT_USERS=$([ ! -z "$AUTH_ENABLED" ] && [ ! -z "$INFLUXDB_ADMIN_USER" ] && echo 1 || echo)
+
+# Check if an environment variable for where to put meta is set.
+# If so, then use that directory, otherwise use the default.
+if [ -z "$INFLUXDB_META_DIR" ]; then
+	META_DIR="/var/lib/influxdb/meta"
+else
+	META_DIR="$INFLUXDB_META_DIR"
+fi
+
+if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -d "$META_DIR" 2>/dev/null)" ]; then
+
+	INIT_QUERY=""
+	CREATE_DB_QUERY="CREATE DATABASE $INFLUXDB_DB"
+
+	if [ ! -z "$INIT_USERS" ]; then
+
+		if [ -z "$INFLUXDB_ADMIN_PASSWORD" ]; then
+			INFLUXDB_ADMIN_PASSWORD="$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32;echo;)"
+			echo "INFLUXDB_ADMIN_PASSWORD:$INFLUXDB_ADMIN_PASSWORD"
+		fi
+
+		INIT_QUERY="CREATE USER \"$INFLUXDB_ADMIN_USER\" WITH PASSWORD '$INFLUXDB_ADMIN_PASSWORD' WITH ALL PRIVILEGES"
+	elif [ ! -z "$INFLUXDB_DB" ]; then
+		INIT_QUERY="$CREATE_DB_QUERY"
+	else
+		INIT_QUERY="SHOW DATABASES"
+	fi
+
+	INFLUXDB_INIT_PORT="8086"
+
+	INFLUXDB_HTTP_BIND_ADDRESS=127.0.0.1:$INFLUXDB_INIT_PORT INFLUXDB_HTTP_HTTPS_ENABLED=false influxd "$@" &
+	pid="$!"
+
+	INFLUX_CMD="influx -host 127.0.0.1 -port $INFLUXDB_INIT_PORT -execute "
+
+	for i in {30..0}; do
+		if $INFLUX_CMD "$INIT_QUERY" &> /dev/null; then
+			break
+		fi
+		echo 'influxdb init process in progress...'
+		sleep 1
+	done
+
+	if [ "$i" = 0 ]; then
+		echo >&2 'influxdb init process failed.'
+		exit 1
+	fi
+
+	if [ ! -z "$INIT_USERS" ]; then
+
+		INFLUX_CMD="influx -host 127.0.0.1 -port $INFLUXDB_INIT_PORT -username ${INFLUXDB_ADMIN_USER} -password ${INFLUXDB_ADMIN_PASSWORD} -execute "
+
+		if [ ! -z "$INFLUXDB_DB" ]; then
+			$INFLUX_CMD "$CREATE_DB_QUERY"
+		fi
+
+		if [ ! -z "$INFLUXDB_USER" ] && [ -z "$INFLUXDB_USER_PASSWORD" ]; then
+			INFLUXDB_USER_PASSWORD="$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32;echo;)"
+			echo "INFLUXDB_USER_PASSWORD:$INFLUXDB_USER_PASSWORD"
+		fi
+
+		if [ ! -z "$INFLUXDB_USER" ]; then
+			$INFLUX_CMD "CREATE USER \"$INFLUXDB_USER\" WITH PASSWORD '$INFLUXDB_USER_PASSWORD'"
+
+			$INFLUX_CMD "REVOKE ALL PRIVILEGES FROM \"$INFLUXDB_USER\""
+
+			if [ ! -z "$INFLUXDB_DB" ]; then
+				$INFLUX_CMD "GRANT ALL ON \"$INFLUXDB_DB\" TO \"$INFLUXDB_USER\""
+			fi
+		fi
+
+		if [ ! -z "$INFLUXDB_WRITE_USER" ] && [ -z "$INFLUXDB_WRITE_USER_PASSWORD" ]; then
+			INFLUXDB_WRITE_USER_PASSWORD="$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32;echo;)"
+			echo "INFLUXDB_WRITE_USER_PASSWORD:$INFLUXDB_WRITE_USER_PASSWORD"
+		fi
+
+		if [ ! -z "$INFLUXDB_WRITE_USER" ]; then
+			$INFLUX_CMD "CREATE USER \"$INFLUXDB_WRITE_USER\" WITH PASSWORD '$INFLUXDB_WRITE_USER_PASSWORD'"
+			$INFLUX_CMD "REVOKE ALL PRIVILEGES FROM \"$INFLUXDB_WRITE_USER\""
+
+			if [ ! -z "$INFLUXDB_DB" ]; then
+				$INFLUX_CMD "GRANT WRITE ON \"$INFLUXDB_DB\" TO \"$INFLUXDB_WRITE_USER\""
+			fi
+		fi
+
+		if [ ! -z "$INFLUXDB_READ_USER" ] && [ -z "$INFLUXDB_READ_USER_PASSWORD" ]; then
+			INFLUXDB_READ_USER_PASSWORD="$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32;echo;)"
+			echo "INFLUXDB_READ_USER_PASSWORD:$INFLUXDB_READ_USER_PASSWORD"
+		fi
+
+		if [ ! -z "$INFLUXDB_READ_USER" ]; then
+			$INFLUX_CMD "CREATE USER \"$INFLUXDB_READ_USER\" WITH PASSWORD '$INFLUXDB_READ_USER_PASSWORD'"
+			$INFLUX_CMD "REVOKE ALL PRIVILEGES FROM \"$INFLUXDB_READ_USER\""
+
+			if [ ! -z "$INFLUXDB_DB" ]; then
+				$INFLUX_CMD "GRANT READ ON \"$INFLUXDB_DB\" TO \"$INFLUXDB_READ_USER\""
+			fi
+		fi
+
+	fi
+
+	for f in /docker-entrypoint-initdb.d/*; do
+		case "$f" in
+			*.sh)     echo "$0: running $f"; . "$f" ;;
+			*.iql)    echo "$0: running $f"; $INFLUX_CMD "$(cat ""$f"")"; echo ;;
+			*)        echo "$0: ignoring $f" ;;
+		esac
+		echo
+	done
+
+	if ! kill -s TERM "$pid" || ! wait "$pid"; then
+		echo >&2 'influxdb init process failed. (Could not stop influxdb)'
+		exit 1
+	fi
+
+fi

--- a/influxdb/1.13/data/entrypoint.sh
+++ b/influxdb/1.13/data/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+export INFLUXDB_HOSTNAME=${INFLUXDB_HOSTNAME:-$HOSTNAME}
+
+if [ "${1:0:1}" = '-' ]; then
+    set -- influxd "$@"
+fi
+
+if [ "$1" = 'influxd' ]; then
+	/init-influxdb.sh "${@:2}"
+fi
+
+exec "$@"

--- a/influxdb/1.13/data/influxdb.conf
+++ b/influxdb/1.13/data/influxdb.conf
@@ -1,0 +1,10 @@
+[meta]
+  dir = "/var/lib/influxdb/meta"
+
+[data]
+  dir = "/var/lib/influxdb/data"
+  engine = "tsm1"
+  wal-dir = "/var/lib/influxdb/wal"
+
+[hinted-handoff]
+  dir = "/var/lib/influxdb/hh"

--- a/influxdb/1.13/data/init-influxdb.sh
+++ b/influxdb/1.13/data/init-influxdb.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+set -e
+
+AUTH_ENABLED="$INFLUXDB_HTTP_AUTH_ENABLED"
+
+if [ -z "$AUTH_ENABLED" ]; then
+	AUTH_ENABLED="$(grep -iE '^\s*auth-enabled\s*=\s*true' /etc/influxdb/influxdb.conf | grep -io 'true' | cat)"
+else
+	AUTH_ENABLED="$(echo "$INFLUXDB_HTTP_AUTH_ENABLED" | grep -io 'true' | cat)"
+fi
+
+INIT_USERS=$([ ! -z "$AUTH_ENABLED" ] && [ ! -z "$INFLUXDB_ADMIN_USER" ] && echo 1 || echo)
+
+# Check if an environment variable for where to put meta is set.
+# If so, then use that directory, otherwise use the default.
+if [ -z "$INFLUXDB_META_DIR" ]; then
+	META_DIR="/var/lib/influxdb/meta"
+else
+	META_DIR="$INFLUXDB_META_DIR"
+fi
+
+if ( [ ! -z "$INIT_USERS" ] || [ ! -z "$INFLUXDB_DB" ] || [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ] ) && [ ! "$(ls -d "$META_DIR" 2>/dev/null)" ]; then
+
+	INIT_QUERY=""
+	CREATE_DB_QUERY="CREATE DATABASE $INFLUXDB_DB"
+
+	if [ ! -z "$INIT_USERS" ]; then
+
+		if [ -z "$INFLUXDB_ADMIN_PASSWORD" ]; then
+			INFLUXDB_ADMIN_PASSWORD="$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32;echo;)"
+			echo "INFLUXDB_ADMIN_PASSWORD:$INFLUXDB_ADMIN_PASSWORD"
+		fi
+
+		INIT_QUERY="CREATE USER \"$INFLUXDB_ADMIN_USER\" WITH PASSWORD '$INFLUXDB_ADMIN_PASSWORD' WITH ALL PRIVILEGES"
+	elif [ ! -z "$INFLUXDB_DB" ]; then
+		INIT_QUERY="$CREATE_DB_QUERY"
+	else
+		INIT_QUERY="SHOW DATABASES"
+	fi
+
+	INFLUXDB_INIT_PORT="8086"
+
+	INFLUXDB_HTTP_BIND_ADDRESS=127.0.0.1:$INFLUXDB_INIT_PORT INFLUXDB_HTTP_HTTPS_ENABLED=false influxd "$@" &
+	pid="$!"
+
+	INFLUX_CMD="influx -host 127.0.0.1 -port $INFLUXDB_INIT_PORT -execute "
+
+	for i in {30..0}; do
+		if $INFLUX_CMD "$INIT_QUERY" &> /dev/null; then
+			break
+		fi
+		echo 'influxdb init process in progress...'
+		sleep 1
+	done
+
+	if [ "$i" = 0 ]; then
+		echo >&2 'influxdb init process failed.'
+		exit 1
+	fi
+
+	if [ ! -z "$INIT_USERS" ]; then
+
+		INFLUX_CMD="influx -host 127.0.0.1 -port $INFLUXDB_INIT_PORT -username ${INFLUXDB_ADMIN_USER} -password ${INFLUXDB_ADMIN_PASSWORD} -execute "
+
+		if [ ! -z "$INFLUXDB_DB" ]; then
+			$INFLUX_CMD "$CREATE_DB_QUERY"
+		fi
+
+		if [ ! -z "$INFLUXDB_USER" ] && [ -z "$INFLUXDB_USER_PASSWORD" ]; then
+			INFLUXDB_USER_PASSWORD="$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32;echo;)"
+			echo "INFLUXDB_USER_PASSWORD:$INFLUXDB_USER_PASSWORD"
+		fi
+
+		if [ ! -z "$INFLUXDB_USER" ]; then
+			$INFLUX_CMD "CREATE USER \"$INFLUXDB_USER\" WITH PASSWORD '$INFLUXDB_USER_PASSWORD'"
+
+			$INFLUX_CMD "REVOKE ALL PRIVILEGES FROM \"$INFLUXDB_USER\""
+
+			if [ ! -z "$INFLUXDB_DB" ]; then
+				$INFLUX_CMD "GRANT ALL ON \"$INFLUXDB_DB\" TO \"$INFLUXDB_USER\""
+			fi
+		fi
+
+		if [ ! -z "$INFLUXDB_WRITE_USER" ] && [ -z "$INFLUXDB_WRITE_USER_PASSWORD" ]; then
+			INFLUXDB_WRITE_USER_PASSWORD="$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32;echo;)"
+			echo "INFLUXDB_WRITE_USER_PASSWORD:$INFLUXDB_WRITE_USER_PASSWORD"
+		fi
+
+		if [ ! -z "$INFLUXDB_WRITE_USER" ]; then
+			$INFLUX_CMD "CREATE USER \"$INFLUXDB_WRITE_USER\" WITH PASSWORD '$INFLUXDB_WRITE_USER_PASSWORD'"
+			$INFLUX_CMD "REVOKE ALL PRIVILEGES FROM \"$INFLUXDB_WRITE_USER\""
+
+			if [ ! -z "$INFLUXDB_DB" ]; then
+				$INFLUX_CMD "GRANT WRITE ON \"$INFLUXDB_DB\" TO \"$INFLUXDB_WRITE_USER\""
+			fi
+		fi
+
+		if [ ! -z "$INFLUXDB_READ_USER" ] && [ -z "$INFLUXDB_READ_USER_PASSWORD" ]; then
+			INFLUXDB_READ_USER_PASSWORD="$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32;echo;)"
+			echo "INFLUXDB_READ_USER_PASSWORD:$INFLUXDB_READ_USER_PASSWORD"
+		fi
+
+		if [ ! -z "$INFLUXDB_READ_USER" ]; then
+			$INFLUX_CMD "CREATE USER \"$INFLUXDB_READ_USER\" WITH PASSWORD '$INFLUXDB_READ_USER_PASSWORD'"
+			$INFLUX_CMD "REVOKE ALL PRIVILEGES FROM \"$INFLUXDB_READ_USER\""
+
+			if [ ! -z "$INFLUXDB_DB" ]; then
+				$INFLUX_CMD "GRANT READ ON \"$INFLUXDB_DB\" TO \"$INFLUXDB_READ_USER\""
+			fi
+		fi
+
+	fi
+
+	for f in /docker-entrypoint-initdb.d/*; do
+		case "$f" in
+			*.sh)     echo "$0: running $f"; . "$f" ;;
+			*.iql)    echo "$0: running $f"; $INFLUX_CMD "$(cat ""$f"")"; echo ;;
+			*)        echo "$0: ignoring $f" ;;
+		esac
+		echo
+	done
+
+	if ! kill -s TERM "$pid" || ! wait "$pid"; then
+		echo >&2 'influxdb init process failed. (Could not stop influxdb)'
+		exit 1
+	fi
+
+fi

--- a/influxdb/1.13/meta/Dockerfile
+++ b/influxdb/1.13/meta/Dockerfile
@@ -1,0 +1,34 @@
+FROM buildpack-deps:bookworm-curl
+
+ENV INFLUXDB_VERSION=1.13.0-c1.13.0
+# INFLUXDB_PR is for suffixes like -1
+ENV INFLUXDB_PR=
+ENV INFLUXDB_PV=${INFLUXDB_VERSION}${INFLUXDB_PR}
+RUN curl -fsSLO "https://dl.influxdata.com/enterprise/releases/influxdb-meta_${INFLUXDB_PV}_amd64.deb.asc" \
+         -fsSLO "https://dl.influxdata.com/enterprise/releases/influxdb-meta_${INFLUXDB_PV}_amd64.deb" && \
+    # Verify InfluxDB 1.X Enterprise \
+    gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys \
+        # InfluxData Package Signing Key <support@influxdata.com> \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 && \
+    gpg --batch --verify \
+        "influxdb-meta_${INFLUXDB_PV}_amd64.deb.asc" \
+        "influxdb-meta_${INFLUXDB_PV}_amd64.deb" && \
+    # Install InfluxDB 1.X Enterprise \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y \
+        "/influxdb-meta_${INFLUXDB_PV}_amd64.deb" && \
+    # Cleanup \
+    rm -r "influxdb-meta_${INFLUXDB_PV}_amd64.deb.asc" \
+          "influxdb-meta_${INFLUXDB_PV}_amd64.deb" \
+          /var/lib/apt/lists/*
+
+COPY influxdb-meta.conf /etc/influxdb/influxdb-meta.conf
+
+EXPOSE 8091
+
+VOLUME /var/lib/influxdb
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["influxd-meta"]

--- a/influxdb/1.13/meta/alpine/Dockerfile
+++ b/influxdb/1.13/meta/alpine/Dockerfile
@@ -1,0 +1,38 @@
+FROM alpine:3.21
+
+RUN apk add --no-cache tzdata bash ca-certificates && \
+    update-ca-certificates
+
+ENV INFLUXDB_VERSION=1.13.0-c1.13.0
+# INFLUXDB_PR is for suffixes like -1
+ENV INFLUXDB_PR=
+ENV INFLUXDB_PV=${INFLUXDB_VERSION}${INFLUXDB_PR}
+RUN apk add --no-cache --virtual .build-deps curl gnupg tar && \
+    curl -fsSLO "https://dl.influxdata.com/enterprise/releases/influxdb-meta-${INFLUXDB_PV}_linux_amd64.tar.gz.asc" \
+         -fsSLO "https://dl.influxdata.com/enterprise/releases/influxdb-meta-${INFLUXDB_PV}_linux_amd64.tar.gz" && \
+    # Verify InfluxDB 1.X Enterprise \
+    gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys \
+        # InfluxData Package Signing Key <support@influxdata.com> \
+        24C975CBA61A024EE1B631787C3D57159FC2F927 && \
+    gpg --batch --verify \
+        "influxdb-meta-${INFLUXDB_PV}_linux_amd64.tar.gz.asc" \
+        "influxdb-meta-${INFLUXDB_PV}_linux_amd64.tar.gz" && \
+    # Install InfluxDB 1.X Enterprise \
+    tar -xvf "influxdb-meta-${INFLUXDB_PV}_linux_amd64.tar.gz" \
+        -C /usr/bin --strip-components 1 --wildcards \
+            'influxdb-*/influxd-ctl' \
+            'influxdb-*/influxd-meta' && \
+    # Cleanup \
+    rm "influxdb-meta-${INFLUXDB_PV}_linux_amd64.tar.gz.asc" \
+       "influxdb-meta-${INFLUXDB_PV}_linux_amd64.tar.gz" && \
+    apk del .build-deps
+
+COPY influxdb-meta.conf /etc/influxdb/influxdb-meta.conf
+
+EXPOSE 8091
+
+VOLUME /var/lib/influxdb
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["influxd-meta"]

--- a/influxdb/1.13/meta/alpine/entrypoint.sh
+++ b/influxdb/1.13/meta/alpine/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+export INFLUXDB_HOSTNAME=${INFLUXDB_HOSTNAME:-$HOSTNAME}
+export INFLUXDB_META_CONFIG_PATH=${INFLUXDB_META_CONFIG_PATH:-/etc/influxdb/influxdb-meta.conf}
+
+if [ "${1:0:1}" = '-' ]; then
+    set -- influxd-meta "$@"
+fi
+
+if [ "$1" = 'influxd-meta' ]; then
+    shift
+    if [ $# -gt 0 ]; then
+        case $1 in
+          config)
+            shift
+            set -- influxd-meta config -config "${INFLUXDB_META_CONFIG_PATH}" "$@"
+            ;;
+          run)
+            shift
+            set -- influxd-meta run -config "${INFLUXDB_META_CONFIG_PATH}" "$@"
+            ;;
+          -*)
+            set -- influxd-meta -config "${INFLUXDB_META_CONFIG_PATH}" "$@"
+            ;;
+          *)
+            set -- influxd-meta "$@"
+            ;;
+        esac
+    else
+        set -- influxd-meta -config "${INFLUXDB_META_CONFIG_PATH}"
+    fi
+fi
+
+exec "$@"

--- a/influxdb/1.13/meta/alpine/influxdb-meta.conf
+++ b/influxdb/1.13/meta/alpine/influxdb-meta.conf
@@ -1,0 +1,2 @@
+[meta]
+  dir = "/var/lib/influxdb/meta"

--- a/influxdb/1.13/meta/entrypoint.sh
+++ b/influxdb/1.13/meta/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+export INFLUXDB_HOSTNAME=${INFLUXDB_HOSTNAME:-$HOSTNAME}
+export INFLUXDB_META_CONFIG_PATH=${INFLUXDB_META_CONFIG_PATH:-/etc/influxdb/influxdb-meta.conf}
+
+if [ "${1:0:1}" = '-' ]; then
+    set -- influxd-meta "$@"
+fi
+
+if [ "$1" = 'influxd-meta' ]; then
+    shift
+    if [ $# -gt 0 ]; then
+        case $1 in
+          config)
+            shift
+            set -- influxd-meta config -config "${INFLUXDB_META_CONFIG_PATH}" "$@"
+            ;;
+          run)
+            shift
+            set -- influxd-meta run -config "${INFLUXDB_META_CONFIG_PATH}" "$@"
+            ;;
+          -*)
+            set -- influxd-meta -config "${INFLUXDB_META_CONFIG_PATH}" "$@"
+            ;;
+          *)
+            set -- influxd-meta "$@"
+            ;;
+        esac
+    else
+        set -- influxd-meta -config "${INFLUXDB_META_CONFIG_PATH}"
+    fi
+fi
+
+exec "$@"

--- a/influxdb/1.13/meta/influxdb-meta.conf
+++ b/influxdb/1.13/meta/influxdb-meta.conf
@@ -1,0 +1,2 @@
+[meta]
+  dir = "/var/lib/influxdb/meta"


### PR DESCRIPTION
Add data node and meta node builds for 1.13.0 (1.13). Single node 1.13.0 builds are excluded for now but will be added soon.