### PR TITLE
chore: update influxdb3 3.11 enterprise image to 3.11.3

### DIFF
--- a/influxdb/3.11-enterprise/Dockerfile
+++ b/influxdb/3.11-enterprise/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.11.2
+ENV INFLUXDB_VERSION=3.11.3
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \


### PR DESCRIPTION
Bump influxdb/3.11-enterprise to 3.11.3, released today from influxdb_pro tag v3.11.3 (0ecc60e2e5).

Enterprise-only patch: no oss/ code changed since 3.11.2, so there is no Core 3.11.3 and influxdb/3.11-core stays at 3.11.2.

Tarballs and .asc signatures for linux amd64 and arm64 are live on dl.influxdata.com. Follow-up: docker-library/official-images PR moving the 3.11-enterprise / 3.11.3-enterprise tags to this commit once merged.