### PR TITLE
chore: 3.9.13 / 3.10.6 / 3.11.4 version updates for influxdb3 core and enterprise

### DIFF
--- a/influxdb/3.10-core/Dockerfile
+++ b/influxdb/3.10-core/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.10.5
+ENV INFLUXDB_VERSION=3.10.6
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \

--- a/influxdb/3.10-enterprise/Dockerfile
+++ b/influxdb/3.10-enterprise/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.10.5
+ENV INFLUXDB_VERSION=3.10.6
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \

--- a/influxdb/3.11-core/Dockerfile
+++ b/influxdb/3.11-core/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.11.2
+ENV INFLUXDB_VERSION=3.11.4
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \

--- a/influxdb/3.11-enterprise/Dockerfile
+++ b/influxdb/3.11-enterprise/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.11.3
+ENV INFLUXDB_VERSION=3.11.4
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \

--- a/influxdb/3.9-core/Dockerfile
+++ b/influxdb/3.9-core/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.9.11
+ENV INFLUXDB_VERSION=3.9.13
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \

--- a/influxdb/3.9-enterprise/Dockerfile
+++ b/influxdb/3.9-enterprise/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd --gid 1500 influxdb3 && \
              /usr/lib/influxdb3 \
              /plugins
 
-ENV INFLUXDB_VERSION=3.9.11
+ENV INFLUXDB_VERSION=3.9.13
 RUN case "$(dpkg --print-architecture)" in \
         amd64) ARCH=amd64 ;; \
         arm64) ARCH=arm64 ;; \


### PR DESCRIPTION
Bumps the core and enterprise images for all three release lines patched today.

Note the images had drifted before this: 3.9 was on 3.9.11, 3.10 on 3.10.5, and 3.11-core on 3.11.2 while 3.11-enterprise was on 3.11.3. All six are now current.

Follow-up docker-library/official-images PR to come.